### PR TITLE
Add audio input monitoring with route change handling

### DIFF
--- a/Aural/TranscriptionView.swift
+++ b/Aural/TranscriptionView.swift
@@ -6,6 +6,7 @@ struct TranscriptionView: View {
     @State private var session = SpeechSession()
     @State private var finalText: AttributedString = ""
     @State private var partialText: AttributedString = ""
+    @State private var micInput: AudioInputInfo?
     @State private var isTranscribing = false
     @State private var error: String?
 
@@ -78,8 +79,29 @@ struct TranscriptionView: View {
             .navigationTitle("Aural")
             .toolbar {
                 if !String(finalText.characters).isEmpty {
-                    ShareLink(item: String(finalText.characters)) {
-                        Image(systemName: "square.and.arrow.up")
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ShareLink(item: String(finalText.characters)) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
+                
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        // show more information about the mic
+                        if let micInput {
+                            print(micInput)
+                        }
+                    } label: {
+                        Image(systemName: micInput?.portIcon ?? "mic")
+                            .contentTransition(.symbolEffect)
+                    }
+                }
+            }
+            .task {
+                for await input in session.audioInputConfigurationStream {
+                    withAnimation {
+                        micInput = input
                     }
                 }
             }

--- a/Sources/AuralKit/AudioInputInfo.swift
+++ b/Sources/AuralKit/AudioInputInfo.swift
@@ -1,0 +1,140 @@
+//
+//  AudioInputInfo.swift
+//  AuralKit
+//
+//  Created by Ifrit on 10/8/25.
+//
+
+import AVFoundation
+
+public struct AudioInputInfo: Sendable, CustomStringConvertible {
+    public let portType: AVAudioSession.Port
+    public let portName: String
+    public let portIcon: String
+    public let uid: String
+    public let hasHardwareVoiceCallProcessing: Bool
+    public let channels: [ChannelInfo]
+    public let dataSources: [DataSourceInfo]?
+    public let selectedDataSource: DataSourceInfo?
+    public let preferredDataSource: DataSourceInfo?
+
+    public var description: String {
+        var desc = """
+        AudioInputInfo:
+        \(portName) (\(portType.rawValue))
+        UID: \(uid)
+        Hardware Voice Processing: \(hasHardwareVoiceCallProcessing ? "✓" : "✗")
+        """
+
+        if !channels.isEmpty {
+            desc += "\nChannels: \(channels.count)"
+            for channel in channels {
+                desc += "\n  • \(channel.channelName) (ch \(channel.channelNumber))"
+            }
+        }
+
+        if let selectedDataSource {
+            desc += "\nData Source: \(selectedDataSource.dataSourceName)"
+            if let location = selectedDataSource.location {
+                desc += " (\(location.rawValue))"
+            }
+            if let pattern = selectedDataSource.selectedPolarPattern {
+                desc += "\n  Polar Pattern: \(pattern.rawValue)"
+            }
+        }
+
+        if let dataSources, dataSources.count > 1 {
+            desc += "\nAvailable Sources: \(dataSources.count)"
+        }
+
+        return desc
+    }
+
+    public struct ChannelInfo: Sendable {
+        public let channelName: String
+        public let channelNumber: Int
+        public let owningPortUID: String
+        public let channelLabel: AudioChannelLabel
+    }
+    
+    public struct DataSourceInfo: Sendable {
+        public let dataSourceID: NSNumber
+        public let dataSourceName: String
+        public let location: AVAudioSession.Location?
+        public let orientation: AVAudioSession.Orientation?
+        public let supportedPolarPatterns: [AVAudioSession.PolarPattern]?
+        public let selectedPolarPattern: AVAudioSession.PolarPattern?
+        public let preferredPolarPattern: AVAudioSession.PolarPattern?
+    }
+    
+    public init(from portDescription: AVAudioSessionPortDescription) {
+        self.portType = portDescription.portType
+        self.portName = portDescription.portName
+        self.portIcon = AudioInputInfo.audioPortToIcon(portDescription)
+        self.uid = portDescription.uid
+        self.hasHardwareVoiceCallProcessing = portDescription.hasHardwareVoiceCallProcessing
+        self.channels = portDescription.channels?.map { channel in
+            ChannelInfo(
+                channelName: channel.channelName,
+                channelNumber: channel.channelNumber,
+                owningPortUID: channel.owningPortUID,
+                channelLabel: channel.channelLabel
+            )
+        } ?? []
+
+        let dataSourceMapper: (AVAudioSessionDataSourceDescription) -> DataSourceInfo = { source in
+            DataSourceInfo(
+                dataSourceID: source.dataSourceID,
+                dataSourceName: source.dataSourceName,
+                location: source.location,
+                orientation: source.orientation,
+                supportedPolarPatterns: source.supportedPolarPatterns,
+                selectedPolarPattern: source.selectedPolarPattern,
+                preferredPolarPattern: source.preferredPolarPattern
+            )
+        }
+
+        self.dataSources = portDescription.dataSources?.map(dataSourceMapper)
+        self.selectedDataSource = portDescription.selectedDataSource.map(dataSourceMapper)
+        self.preferredDataSource = portDescription.preferredDataSource.map(dataSourceMapper)
+    }
+}
+
+// UI Helper
+extension AudioInputInfo {
+#if os(iOS)
+    private static func audioPortToIcon(_ port: AVAudioSessionPortDescription) -> String {
+        let portName = port.portName.lowercased()
+        let portType = port.portType
+        
+        if portName.contains("pro") {
+            return "airpods.pro"
+        } else if portName.contains("max") {
+            return "airpods.max"
+        } else if portName.contains("airpods") {
+            return "airpods"
+        }
+        
+        switch portType {
+        case .bluetoothA2DP, .bluetoothHFP, .bluetoothLE:
+            if portName.contains("beats") {
+                return "beats.headphones"
+            } else if portName.contains("headphone") || portName.contains("headset") {
+                return "headphones"
+            } else {
+                return "airpods.gen4"
+            }
+        case .builtInMic:
+            return "mic"
+        case .headsetMic:
+            return "headphones"
+        case .lineIn:
+            return "cable.connector"
+        case .usbAudio:
+            return "music.microphone"
+        default:
+            return "mic"
+        }
+    }
+#endif
+}


### PR DESCRIPTION
- Created AudioInputInfo struct to encapsulate AVAudioSession port details without requiring main targets to import AVFoundation
- Added audioInputConfigurationStream to SpeechSession for monitoring audio input changes (microphone, AirPods, etc.)
- Implemented automatic audio engine reset on route changes to handle device switching seamlessly
- Added proper cleanup in deinit for notification observers and stream continuations

Technical note: Currently the stream only yields values after audio starts flowing (when AVAudioSession is activated). The stream could be made to flow immediately on SpeechSession creation if we configure AVAudioSession on app launch instead of when transcription starts. This would allow consumers to get mic info right away instead of waiting for the engine to start. It's up to you.