### PR TITLE
Main-actor SpeechSession refactor

### DIFF
--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -1,0 +1,147 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+extension SpeechSession {
+
+    // MARK: - Audio Streaming
+
+    func startAudioStreaming() throws {
+        guard !isAudioStreaming else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+
+        audioEngine.inputNode.removeTap(onBus: 0)
+
+        let inputFormat = audioEngine.inputNode.outputFormat(forBus: 0)
+
+        audioEngine.inputNode.installTap(
+            onBus: 0,
+            bufferSize: 4096,
+            format: inputFormat
+        ) { [weak self] buffer, _ in
+            guard let self,
+                  let bufferCopy = buffer.copy() as? AVAudioPCMBuffer else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try self.processAudioBuffer(bufferCopy)
+                } catch {
+                    print("Audio processing error: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        isAudioStreaming = true
+    }
+
+    func stopAudioStreaming() {
+        guard isAudioStreaming else { return }
+        audioEngine.stop()
+        isAudioStreaming = false
+    }
+
+    func setupAudioConfigurationObservers() {
+#if os(iOS)
+        routeChangeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let userInfo = notification.userInfo,
+                  let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+                  let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
+                return
+            }
+
+            let previousPortType = (userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription)?
+                .inputs.first?.portType
+
+            Task { [weak self] in
+                guard let self else { return }
+                await self.handleRouteChange(reason, previousPortType: previousPortType)
+            }
+        }
+#elseif os(macOS)
+        routeChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: audioEngine,
+            queue: .main
+        ) { [weak self] _ in
+            Task { [weak self] in
+                guard let self else { return }
+                await self.handleEngineConfigurationChange()
+            }
+        }
+#endif
+    }
+
+#if os(iOS)
+    func handleRouteChange(_ reason: AVAudioSession.RouteChangeReason, previousPortType: AVAudioSession.Port?) async {
+        let session = AVAudioSession.sharedInstance()
+        let currentPortType = session.currentRoute.inputs.first?.portType
+
+        guard previousPortType != currentPortType else {
+            return
+        }
+
+        do {
+            try await reset()
+        } catch {
+            print("Failed to reset audio engine after route change: \(error.localizedDescription)")
+        }
+
+        publishCurrentAudioInputInfo()
+    }
+#elseif os(macOS)
+    func handleEngineConfigurationChange() async {
+        do {
+            try await reset()
+        } catch {
+            print("Failed to reset audio engine after configuration change: \(error.localizedDescription)")
+        }
+
+        publishCurrentAudioInputInfo()
+    }
+#endif
+
+#if os(iOS) || os(macOS)
+    func publishCurrentAudioInputInfo() {
+#if os(iOS)
+        let audioSession = AVAudioSession.sharedInstance()
+        if let input = audioSession.currentRoute.inputs.first {
+            audioInputConfigurationContinuation?.yield(AudioInputInfo(from: input))
+        } else {
+            audioInputConfigurationContinuation?.yield(nil)
+        }
+#elseif os(macOS)
+        do {
+            let info = try AudioInputInfo.current()
+            audioInputConfigurationContinuation?.yield(info)
+        } catch {
+            print("Failed to obtain audio input details: \(error.localizedDescription)")
+            audioInputConfigurationContinuation?.yield(nil)
+        }
+#endif
+    }
+#endif
+
+    func reset() async throws {
+        let wasStreaming = isAudioStreaming
+
+        if wasStreaming {
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+
+        audioEngine.stop()
+        audioEngine.reset()
+        isAudioStreaming = false
+
+        guard wasStreaming else { return }
+        try startAudioStreaming()
+    }
+}

--- a/Sources/AuralKit/SpeechSession+Pipeline.swift
+++ b/Sources/AuralKit/SpeechSession+Pipeline.swift
@@ -1,0 +1,86 @@
+import Foundation
+import AVFoundation
+import Speech
+
+@MainActor
+extension SpeechSession {
+
+    // MARK: - Pipeline Orchestration
+
+    func startPipeline(
+        with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+    ) async {
+        do {
+            try await permissionsManager.ensurePermissions()
+
+#if os(iOS)
+            try await MainActor.run {
+                let audioSession = AVAudioSession.sharedInstance()
+                try audioSession.setCategory(audioConfig.category, mode: audioConfig.mode, options: audioConfig.options)
+                try audioSession.setActive(true)
+            }
+#endif
+#if os(iOS) || os(macOS)
+            publishCurrentAudioInputInfo()
+#endif
+
+            let transcriber = try await setUpTranscriber(contextualStrings: contextualStrings)
+
+            recognizerTask = Task<Void, Never> { [weak self] in
+                guard let self else { return }
+
+                do {
+                    for try await result in transcriber.results {
+                        streamContinuation.yield(result)
+                    }
+                    await self.finishFromRecognizerTask(error: nil)
+                } catch is CancellationError {
+                    // Cancellation handled by cleanup logic
+                } catch {
+                    await self.finishFromRecognizerTask(error: error)
+                }
+            }
+
+            try startAudioStreaming()
+
+            streamingActive = true
+        } catch {
+            await finishWithStartupError(error)
+        }
+    }
+
+    func finishWithStartupError(_ error: Error) async {
+        await cleanup(cancelRecognizer: true)
+        await finishStream(error: error)
+    }
+
+    func finishFromRecognizerTask(error: Error?) async {
+        await cleanup(cancelRecognizer: false)
+        await finishStream(error: error)
+    }
+
+    func cleanup(cancelRecognizer: Bool) async {
+        let task = recognizerTask
+        recognizerTask = nil
+
+        if cancelRecognizer {
+            task?.cancel()
+        }
+
+        streamingActive = false
+        stopAudioStreaming()
+        await stopTranscriberAndCleanup()
+    }
+
+    func finishStream(error: Error?) async {
+        guard let cont = continuation else { return }
+        continuation = nil
+
+        if let error {
+            cont.finish(throwing: error)
+        } else {
+            cont.finish()
+        }
+    }
+}

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -1,0 +1,78 @@
+import Foundation
+import AVFoundation
+import Speech
+
+@MainActor
+extension SpeechSession {
+
+    // MARK: - Transcriber Setup and Cleanup
+
+    func setUpTranscriber(
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+    ) async throws -> SpeechTranscriber {
+        transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: reportingOptions,
+            attributeOptions: attributeOptions
+        )
+
+        guard let transcriber else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+
+        analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        try await modelManager.ensureModel(transcriber: transcriber, locale: locale)
+
+        if let contextualStrings, !contextualStrings.isEmpty, let analyzer {
+            let analysisContext = AnalysisContext()
+            for (tag, strings) in contextualStrings {
+                analysisContext.contextualStrings[tag] = strings
+            }
+            do {
+                try await analyzer.setContext(analysisContext)
+            } catch {
+                throw SpeechSessionError.contextSetupFailed(error)
+            }
+        }
+
+        analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
+        (inputSequence, inputBuilder) = AsyncStream<AnalyzerInput>.makeStream()
+
+        guard let inputSequence else { return transcriber }
+
+        try await analyzer?.start(inputSequence: inputSequence)
+
+        return transcriber
+    }
+
+    func processAudioBuffer(_ buffer: AVAudioPCMBuffer) throws {
+        guard let inputBuilder, let analyzerFormat else {
+            throw SpeechSessionError.invalidAudioDataType
+        }
+
+        let converted = try converter.convertBuffer(buffer, to: analyzerFormat)
+        let input = AnalyzerInput(buffer: converted)
+        inputBuilder.yield(input)
+    }
+
+    func stopTranscriberAndCleanup() async {
+        inputBuilder?.finish()
+
+        do {
+            try await analyzer?.finalizeAndFinishThroughEndOfInput()
+        } catch {
+            // Finalization failed, but we still need to clean up resources
+            // Log for debugging but don't propagate since stop() is best-effort cleanup
+        }
+
+        await modelManager.releaseLocales()
+
+        inputBuilder = nil
+        inputSequence = nil
+        analyzerFormat = nil
+        analyzer = nil
+        transcriber = nil
+    }
+}

--- a/Tests/AuralKitTests/AuralKitTests.swift
+++ b/Tests/AuralKitTests/AuralKitTests.swift
@@ -5,6 +5,7 @@ import Testing
 struct AuralKitTests {
 
     @Test("Model download progress starts nil")
+    @MainActor
     func testInitialDownloadProgressIsNil() {
         let kit = SpeechSession()
         #expect(kit.modelDownloadProgress == nil)


### PR DESCRIPTION
## Summary
- isolate SpeechSession on the main actor and keep the public surface in the primary file
- split pipeline, audio, and transcriber helpers into focused extensions
- adjust the unit test to run on MainActor and keep audio tap work serialized

## Testing
- swift build
- swift test
