### PR TITLE
Add device capability helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,10 @@ if capabilities.supportsDictationTranscriber {
 }
 
 let supportedIdentifiers = capabilities.supportedLocales.map { $0.identifier(.bcp47) }
-print("Supports up to \(capabilities.maxReservedLocales) reserved locales")
+print("Supports up to \(capabilities.maxReservedLocales) reserved locales: \(supportedIdentifiers)")
+
+let dictationIdentifiers = capabilities.supportedDictationLocales.map { $0.identifier(.bcp47) }
+print("Dictation transcriber supports: \(dictationIdentifiers)")
 ```
 
 Use the returned metadata to populate locale pickers, display download guidance, or gracefully disable transcription when models are unavailable.

--- a/Sources/AuralKit/DeviceCapabilities.swift
+++ b/Sources/AuralKit/DeviceCapabilities.swift
@@ -5,6 +5,7 @@ public struct DeviceCapabilities: Sendable {
     public let supportsSpeechTranscriber: Bool
     public let supportsDictationTranscriber: Bool
     public let supportedLocales: [Locale]
+    public let supportedDictationLocales: [Locale]
     public let installedLocales: [Locale]
     public let maxReservedLocales: Int
 
@@ -12,12 +13,14 @@ public struct DeviceCapabilities: Sendable {
         supportsSpeechTranscriber: Bool,
         supportsDictationTranscriber: Bool,
         supportedLocales: [Locale],
+        supportedDictationLocales: [Locale],
         installedLocales: [Locale],
         maxReservedLocales: Int
     ) {
         self.supportsSpeechTranscriber = supportsSpeechTranscriber
         self.supportsDictationTranscriber = supportsDictationTranscriber
         self.supportedLocales = supportedLocales
+        self.supportedDictationLocales = supportedDictationLocales
         self.installedLocales = installedLocales
         self.maxReservedLocales = maxReservedLocales
     }
@@ -41,6 +44,7 @@ extension SpeechSession {
             supportsSpeechTranscriber: supportsSpeechTranscriber,
             supportsDictationTranscriber: supportsDictationTranscriber,
             supportedLocales: supportedLocales,
+            supportedDictationLocales: dictationLocales,
             installedLocales: installedLocales,
             maxReservedLocales: AssetInventory.maximumReservedLocales
         )


### PR DESCRIPTION
## Summary
- add a public `DeviceCapabilities` struct and `SpeechSession.deviceCapabilities()` helper to surface module availability and locale metadata
- document the helper in the README and highlight the new capability in the feature list

## Testing
- swift build *(fails: package requires Swift tools version 6.2.0 but 6.1.0 is installed in CI environment)*