### PR TITLE
[codex] Fix Swift test iterator concurrency

### DIFF
--- a/Tests/AuralKitTests/AuralKitTests.swift
+++ b/Tests/AuralKitTests/AuralKitTests.swift
@@ -48,24 +48,24 @@ struct SpeechSessionStateTests {
     func statusStreamBroadcastsToMultipleSubscribers() async throws {
         let session = SpeechSession()
 
-        var iteratorA = session.statusStream.makeAsyncIterator()
-        var iteratorB = session.statusStream.makeAsyncIterator()
+        let probeA = AsyncStreamProbe(session.statusStream)
+        let probeB = AsyncStreamProbe(session.statusStream)
 
         let firstA = try await awaitResult {
-            await iteratorA.next()
+            await probeA.next()
         }
         let firstB = try await awaitResult {
-            await iteratorB.next()
+            await probeB.next()
         }
 
         #expect(firstA == .some(.idle))
         #expect(firstB == .some(.idle))
 
         let nextA = Task {
-            await iteratorA.next()
+            await probeA.next()
         }
         let nextB = Task {
-            await iteratorB.next()
+            await probeB.next()
         }
         defer {
             nextA.cancel()
@@ -129,14 +129,14 @@ struct SpeechSessionAudioInputStreamTests {
     func audioInputStreamBroadcastsNil() async throws {
         let session = SpeechSession()
 
-        var iteratorA = session.audioInputConfigurationStream.makeAsyncIterator()
-        var iteratorB = session.audioInputConfigurationStream.makeAsyncIterator()
+        let probeA = AsyncStreamProbe(session.audioInputConfigurationStream)
+        let probeB = AsyncStreamProbe(session.audioInputConfigurationStream)
 
         let valueA = Task {
-            await iteratorA.next()
+            await probeA.next()
         }
         let valueB = Task {
-            await iteratorB.next()
+            await probeB.next()
         }
         defer {
             valueA.cancel()

--- a/Tests/AuralKitTests/TestTimeoutHelpers.swift
+++ b/Tests/AuralKitTests/TestTimeoutHelpers.swift
@@ -11,6 +11,18 @@ enum TestTimeoutError: LocalizedError {
     }
 }
 
+final class AsyncStreamProbe<Element: Sendable>: @unchecked Sendable {
+    private var iterator: AsyncStream<Element>.Iterator
+
+    init(_ stream: AsyncStream<Element>) {
+        iterator = stream.makeAsyncIterator()
+    }
+
+    func next() async -> Element? {
+        await iterator.next()
+    }
+}
+
 @MainActor
 func awaitResult<T: Sendable>(
     timeout seconds: TimeInterval = 1.0,


### PR DESCRIPTION
## What changed

- Added a small test-only `AsyncStreamProbe` wrapper that owns `AsyncStream` iterators outside main-actor local state.
- Updated status and audio-input fan-out tests to use the probe instead of directly advancing main-actor-isolated iterators.

## Why

Swift 6.3 rejects the previous test pattern because calling `iterator.next()` from async tasks risks sending main actor-isolated iterator state through a nonisolated async method. This made `swift test` fail at compile time.

## Validation

- `swift test`
- `swiftlint lint --strict`
- `git diff --check`

## Stack

This is the base PR for the remaining focused fixes.