### PR TITLE
[codex] Gate SpeechDetector compatibility shim

### DIFF
--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -3,8 +3,10 @@ import AVFoundation
 import Speech
 
 // SpeechDetector gained native SpeechModule and Sendable conformances in Xcode 26.2.
-// This extension is required for Xcode 26.0/26.1 and causes a harmless warning on 26.2+.
+// Keep this shim for Xcode 26.0/26.1 while avoiding duplicate conformances in newer SDKs.
+#if compiler(<6.3)
 extension SpeechDetector: @retroactive SpeechModule, @unchecked @retroactive Sendable {}
+#endif
 
 @MainActor
 extension SpeechSession {


### PR DESCRIPTION
## What changed

- Wrapped the retroactive `SpeechDetector` compatibility conformances in `#if compiler(<6.3)`.
- Kept the shim available for older Xcode 26.0/26.1-era compilers while avoiding duplicate-conformance warnings on the current Swift 6.3 toolchain.

## Why

Newer Speech SDKs already declare `SpeechDetector: SpeechModule, Sendable`, so the unconditional retroactive extension produced duplicate-conformance compiler warnings.

## Validation

- `swift test`
- `swiftlint lint --strict`

## Stack

Base: #25 (`codex/fix-swift-test-iterator-concurrency`).