### PR TITLE
[codex] Finalize file transcription input

### DIFF
--- a/Sources/AuralKit/SpeechSession+File.swift
+++ b/Sources/AuralKit/SpeechSession+File.swift
@@ -331,9 +331,9 @@ private extension SpeechSession {
             }
         }
 
-        await MainActor.run {
-            self.inputBuilder?.finish()
-        }
+        guard !Task.isCancelled else { return false }
+
+        try await self.finishAnalyzerInput()
 
         return !Task.isCancelled && processedFrames >= totalFrames
     }

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -215,14 +215,18 @@ extension SpeechSession {
         inputBuilder.yield(input)
     }
 
-    func stopTranscriberAndCleanup() async {
+    func finishAnalyzerInput() async throws {
         inputBuilder?.finish()
+        try await analyzer?.finalizeAndFinishThroughEndOfInput()
+    }
+
+    func stopTranscriberAndCleanup() async {
         if Self.shouldLog(.debug) {
             Self.logger.debug("Stopping transcriber and cleaning up")
         }
 
         do {
-            try await analyzer?.finalizeAndFinishThroughEndOfInput()
+            try await finishAnalyzerInput()
         } catch {
             // Finalization failed, but we still need to clean up resources
             // Log for debugging but don't propagate since stop() is best-effort cleanup


### PR DESCRIPTION
## What changed

- Added a shared `finishAnalyzerInput()` helper that finishes analyzer input and calls `finalizeAndFinishThroughEndOfInput()` together.
- Calls that helper after file ingestion feeds all buffers, so file transcription can flush final results and let the recognizer stream complete naturally.
- Reuses the helper in best-effort cleanup.

## Why

For file transcription, merely finishing `inputBuilder` does not finish analysis. Without explicit analyzer finalization, file transcription could wait indefinitely for the recognizer result stream to end.

## Validation

- `swift test`
- `swiftlint lint --strict`

## Stack

Base: #26 (`codex/fix-speechdetector-compat-warning`).