### PR TITLE
[codex] Align custom vocabulary demo locale

### DIFF
--- a/Aural/CustomVocabularyDemoViewModel.swift
+++ b/Aural/CustomVocabularyDemoViewModel.swift
@@ -31,7 +31,8 @@ final class CustomVocabularyDemoViewModel {
 
     // MARK: - Private state
 
-    private let locale = Locale(identifier: "en_US")
+    private static let demoLocale = Locale(identifier: "en_US")
+    private let locale = demoLocale
     @ObservationIgnored private let session: SpeechSession
     @ObservationIgnored private var statusTask: Task<Void, Never>?
     @ObservationIgnored private var transcriptionTask: Task<Void, Never>?
@@ -41,7 +42,7 @@ final class CustomVocabularyDemoViewModel {
 
     // MARK: - Init / Deinit
 
-    init(session: SpeechSession = SpeechSession()) {
+    init(session: SpeechSession = SpeechSession(locale: demoLocale)) {
         self.session = session
         bindStatusStream()
     }


### PR DESCRIPTION
## What changed

- Introduced a shared demo locale for the custom vocabulary sample.
- Initializes the default `SpeechSession` with that same locale while preserving session injection for tests/previews.

## Why

The demo builds its custom vocabulary for `en_US`, but the default session previously used `.current`. On non-`en_US` systems, configuring the demo vocabulary failed with a locale mismatch before transcription could start.

## Validation

- `swift test`
- `swiftlint lint --strict`

## Stack

Base: #26 (`codex/fix-speechdetector-compat-warning`).