### PR TITLE
Add guarded native file transcription path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ AuralKit is a simple, lightweight Swift wrapper for speech-to-text transcription
 - Audio input monitoring for device route changes on iOS and macOS
 - Async streams for lifecycle status, audio inputs, and transcription results
 - Device capability helper to inspect available transcribers and locales
+- Xcode 27-ready file transcription path that can use Speech's native analyzer file input when built with Swift 6.4+
 - SwiftUI-friendly API that mirrors Apple's sample project design
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AuralKit is a simple, lightweight Swift wrapper for speech-to-text transcription
 - Async streams for lifecycle status, audio inputs, and transcription results
 - Device capability helper to inspect available transcribers and locales
 - Xcode 27-ready file transcription path that can use Speech's native analyzer file input when built with Swift 6.4+
+- Xcode 27-ready live capture and analyzer preheating configuration with Xcode 26 fallbacks
 - SwiftUI-friendly API that mirrors Apple's sample project design
 
 ## Table of Contents

--- a/Sources/AuralKit/SpeechSession+AnalyzerOptions.swift
+++ b/Sources/AuralKit/SpeechSession+AnalyzerOptions.swift
@@ -1,0 +1,50 @@
+import Foundation
+import AVFoundation
+import Speech
+
+extension SpeechSession {
+    func prepareAnalyzerForStartIfNeeded(in audioFormat: AVAudioFormat?) async throws {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            try await prepareNativeAnalyzerForStart(in: audioFormat)
+        }
+#endif
+    }
+}
+
+#if swift(>=6.4)
+@available(iOS 27.0, macOS 27.0, *)
+extension SpeechSession.AnalyzerConfiguration {
+    var nativeOptions: SpeechAnalyzer.Options {
+        SpeechAnalyzer.Options(
+            priority: priority,
+            modelRetention: modelRetention.nativeValue
+        )
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, *)
+extension SpeechSession.AnalyzerModelRetention {
+    var nativeValue: SpeechAnalyzer.Options.ModelRetention {
+        switch self {
+        case .whileInUse:
+            return .whileInUse
+        case .lingering:
+            return .lingering
+        case .processLifetime:
+            return .processLifetime
+        }
+    }
+}
+
+@available(iOS 27.0, macOS 27.0, *)
+extension SpeechSession {
+    func prepareNativeAnalyzerForStart(in audioFormat: AVAudioFormat?) async throws {
+        guard analyzerConfiguration.preparesAnalyzerBeforeStart, let analyzer else {
+            return
+        }
+
+        try await analyzer.prepareToAnalyze(in: audioFormat)
+    }
+}
+#endif

--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -13,6 +13,12 @@ extension SpeechSession {
             throw SpeechSessionError.recognitionStreamSetupFailed
         }
 
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), startPreparedNativeCaptureStreaming() {
+            return
+        }
+#endif
+
         if Self.shouldLog(.debug) {
             Self.logger.debug("Starting audio streaming")
         }
@@ -43,6 +49,13 @@ extension SpeechSession {
 
     func stopAudioStreaming() {
         guard isAudioStreaming else { return }
+
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), stopPreparedNativeCaptureStreaming() {
+            return
+        }
+#endif
+
         if Self.shouldLog(.debug) {
             Self.logger.debug("Stopping audio streaming")
         }

--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -307,11 +307,8 @@ extension SpeechSession {
         let wasUsingNativeCapture = nativeCaptureSession != nil
 
         if wasUsingNativeCapture {
-            tearDownNativeCaptureStreaming()
-            isAudioStreaming = false
-
             guard wasStreaming else { return }
-            guard try await setUpNativeCaptureStreamingIfAvailable() else {
+            guard try restartNativeCaptureStreamingIfAvailable() else {
                 throw SpeechSessionError.recognitionStreamSetupFailed
             }
 

--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -304,6 +304,22 @@ extension SpeechSession {
             Self.logger.debug("Resetting audio engine")
         }
         let wasStreaming = isAudioStreaming
+        let wasUsingNativeCapture = nativeCaptureSession != nil
+
+        if wasUsingNativeCapture {
+            tearDownNativeCaptureStreaming()
+            isAudioStreaming = false
+
+            guard wasStreaming else { return }
+            guard try await setUpNativeCaptureStreamingIfAvailable() else {
+                throw SpeechSessionError.recognitionStreamSetupFailed
+            }
+
+            if Self.shouldLog(.debug) {
+                Self.logger.debug("Native capture session reset complete")
+            }
+            return
+        }
 
         if wasStreaming {
             audioEngine.inputNode.removeTap(onBus: 0)

--- a/Sources/AuralKit/SpeechSession+Configuration.swift
+++ b/Sources/AuralKit/SpeechSession+Configuration.swift
@@ -18,6 +18,44 @@ public extension SpeechSession {
         .transcriptionConfidence
     ]
 
+    /// Configuration for `SpeechAnalyzer` startup and model caching behavior.
+    struct AnalyzerConfiguration: Equatable, Sendable {
+        /// Preferred priority for analyzer work on OS versions that expose analyzer options.
+        public var priority: TaskPriority
+
+        /// Preferred model caching strategy on OS versions that expose analyzer options.
+        public var modelRetention: AnalyzerModelRetention
+
+        /// When true, asks the analyzer to prepare before audio starts flowing when supported.
+        public var preparesAnalyzerBeforeStart: Bool
+
+        /// Creates analyzer configuration.
+        public init(
+            priority: TaskPriority = .userInitiated,
+            modelRetention: AnalyzerModelRetention = .lingering,
+            preparesAnalyzerBeforeStart: Bool = true
+        ) {
+            self.priority = priority
+            self.modelRetention = modelRetention
+            self.preparesAnalyzerBeforeStart = preparesAnalyzerBeforeStart
+        }
+
+        /// Default analyzer configuration.
+        public static let `default` = AnalyzerConfiguration()
+    }
+
+    /// Model retention strategies that map to `SpeechAnalyzer.Options.ModelRetention` when available.
+    enum AnalyzerModelRetention: Equatable, Sendable, CaseIterable {
+        /// Release models when the analyzer is deallocated.
+        case whileInUse
+
+        /// Keep models in memory briefly for compatible future analyzer sessions.
+        case lingering
+
+        /// Keep models in memory until the process exits.
+        case processLifetime
+    }
+
 #if os(iOS)
     /// Declarative wrapper describing how `SpeechSession` should configure `AVAudioSession` on iOS.
     struct AudioSessionConfiguration: Sendable {

--- a/Sources/AuralKit/SpeechSession+File.swift
+++ b/Sources/AuralKit/SpeechSession+File.swift
@@ -140,9 +140,11 @@ private extension SpeechSession {
         do {
             let validation = try validateAudioFile(at: audioFileURL, options: options)
             try await ensureSpeechRecognitionAuthorization(context: "for file transcription")
+            let shouldUseNativeAnalyzer = shouldUseNativeFileAnalyzer(progressHandler: progressHandler)
             try await setUpFilePipeline(
                 with: streamContinuation,
-                contextualStrings: options.contextualStrings
+                contextualStrings: options.contextualStrings,
+                startAnalyzerImmediately: !shouldUseNativeAnalyzer
             )
             let handler = progressHandler
             fileIngestionTask = Task<Void, Never> { [weak self] in
@@ -240,26 +242,16 @@ private extension SpeechSession {
 
     func setUpFilePipeline(
         with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]?
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]?,
+        startAnalyzerImmediately: Bool
     ) async throws {
         if Self.shouldLog(.notice) {
             Self.logger.notice("Starting file transcription pipeline")
         }
 
-#if swift(>=6.4)
-        let shouldUseNativeAnalyzer: Bool
-        if #available(iOS 27.0, macOS 27.0, *) {
-            shouldUseNativeAnalyzer = inputProviderPreference == .automatic
-        } else {
-            shouldUseNativeAnalyzer = false
-        }
-#else
-        let shouldUseNativeAnalyzer = false
-#endif
-
         let transcriber = try await setUpSpeechTranscriber(
             contextualStrings: contextualStrings,
-            startAnalyzerImmediately: !shouldUseNativeAnalyzer
+            startAnalyzerImmediately: startAnalyzerImmediately
         )
         activeResultKind = .speech
 
@@ -300,7 +292,9 @@ private extension SpeechSession {
         progressHandler: (@Sendable (Double) -> Void)?
     ) async throws -> Bool {
 #if swift(>=6.4)
-        if #available(iOS 27.0, macOS 27.0, *), await shouldUseNativeAssetInputProvider {
+        if #available(iOS 27.0, macOS 27.0, *),
+           progressHandler == nil,
+           await shouldUseNativeAssetInputProvider {
             return try await feedAudioFileWithNativeAnalyzer(payload.file, progressHandler: progressHandler)
         }
 #endif
@@ -356,6 +350,15 @@ private extension SpeechSession {
         try await self.finishAnalyzerInput()
 
         return !Task.isCancelled && processedFrames >= totalFrames
+    }
+
+    func shouldUseNativeFileAnalyzer(progressHandler: (@Sendable (Double) -> Void)?) -> Bool {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            return inputProviderPreference == .automatic && progressHandler == nil
+        }
+#endif
+        return false
     }
 
 }

--- a/Sources/AuralKit/SpeechSession+File.swift
+++ b/Sources/AuralKit/SpeechSession+File.swift
@@ -246,7 +246,21 @@ private extension SpeechSession {
             Self.logger.notice("Starting file transcription pipeline")
         }
 
-        let transcriber = try await setUpSpeechTranscriber(contextualStrings: contextualStrings)
+#if swift(>=6.4)
+        let shouldUseNativeAnalyzer: Bool
+        if #available(iOS 27.0, macOS 27.0, *) {
+            shouldUseNativeAnalyzer = inputProviderPreference == .automatic
+        } else {
+            shouldUseNativeAnalyzer = false
+        }
+#else
+        let shouldUseNativeAnalyzer = false
+#endif
+
+        let transcriber = try await setUpSpeechTranscriber(
+            contextualStrings: contextualStrings,
+            startAnalyzerImmediately: !shouldUseNativeAnalyzer
+        )
         activeResultKind = .speech
 
         recognizerTask = Task<Void, Never> { [weak self] in
@@ -285,6 +299,12 @@ private extension SpeechSession {
         _ payload: (file: AVAudioFile, totalFrames: AVAudioFramePosition),
         progressHandler: (@Sendable (Double) -> Void)?
     ) async throws -> Bool {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), await shouldUseNativeAssetInputProvider {
+            return try await feedAudioFileWithNativeAnalyzer(payload.file, progressHandler: progressHandler)
+        }
+#endif
+
         var processedFrames: AVAudioFramePosition = 0
         let frameCapacity: AVAudioFrameCount = 4096
         let file = payload.file

--- a/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
@@ -76,6 +76,7 @@ extension SpeechSession {
                 await self?.finishFromNativeCaptureAnalysis(error)
             }
         }
+        startSpeechDetectorMonitoringIfNeeded()
 
         _ = startPreparedNativeCaptureStreaming()
     }

--- a/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
@@ -29,6 +29,19 @@ extension SpeechSession {
         }
 #endif
     }
+
+    func restartNativeCaptureStreamingIfAvailable() throws -> Bool {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            guard stopPreparedNativeCaptureStreaming(),
+                  startPreparedNativeCaptureStreaming() else {
+                throw SpeechSessionError.recognitionStreamSetupFailed
+            }
+            return true
+        }
+#endif
+        return false
+    }
 }
 
 #if swift(>=6.4)

--- a/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
@@ -1,0 +1,119 @@
+import Foundation
+@preconcurrency import AVFoundation
+import Speech
+
+extension SpeechSession {
+    var shouldUseNativeCaptureInputProvider: Bool {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            return inputProviderPreference == .automatic
+        }
+#endif
+        return false
+    }
+
+    func setUpNativeCaptureStreamingIfAvailable() async throws -> Bool {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *), shouldUseNativeCaptureInputProvider {
+            try await setUpNativeCaptureStreaming()
+            return true
+        }
+#endif
+        return false
+    }
+
+    func tearDownNativeCaptureStreaming() {
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            tearDownNativeCaptureStreamingIfAvailable()
+        }
+#endif
+    }
+}
+
+#if swift(>=6.4)
+@available(iOS 27.0, macOS 27.0, *)
+extension SpeechSession {
+    private var canUseNativeCaptureInputProvider: Bool {
+        inputProviderPreference == .automatic
+    }
+
+    func setUpNativeCaptureStreaming() async throws {
+        guard !isAudioStreaming else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+        guard canUseNativeCaptureInputProvider else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+        guard let modules = activeModules, let analyzer else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+        guard let captureDevice = AVCaptureDevice.default(for: .audio) else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+
+        let provider = try await CaptureInputSequenceProvider.providerWithSession(
+            from: captureDevice,
+            compatibleWith: modules,
+            priority: analyzerConfiguration.priority
+        )
+        nativeCaptureSession = provider.captureSession
+
+        try await prepareAnalyzerForStartIfNeeded(in: nil)
+
+        let analyzerInputs = provider.analyzerInputs
+        nativeCaptureAnalysisTask = Task<Void, Never> { [weak self, analyzer, analyzerInputs] in
+            do {
+                let lastAudioTime = try await analyzer.analyzeSequence(analyzerInputs)
+                if let lastAudioTime {
+                    try await analyzer.finalizeAndFinish(through: lastAudioTime)
+                } else {
+                    try await analyzer.finalizeAndFinishThroughEndOfInput()
+                }
+            } catch is CancellationError {
+                // Cancellation is expected during explicit cleanup.
+            } catch {
+                await self?.finishFromNativeCaptureAnalysis(error)
+            }
+        }
+
+        _ = startPreparedNativeCaptureStreaming()
+    }
+
+    func startPreparedNativeCaptureStreaming() -> Bool {
+        guard let nativeCaptureSession else { return false }
+
+        if Self.shouldLog(.debug) {
+            Self.logger.debug("Starting native capture session")
+        }
+        nativeCaptureSession.startRunning()
+        isAudioStreaming = true
+        return true
+    }
+
+    func stopPreparedNativeCaptureStreaming() -> Bool {
+        guard let nativeCaptureSession else { return false }
+
+        if Self.shouldLog(.debug) {
+            Self.logger.debug("Stopping native capture session")
+        }
+        nativeCaptureSession.stopRunning()
+        isAudioStreaming = false
+        return true
+    }
+
+    func tearDownNativeCaptureStreamingIfAvailable() {
+        nativeCaptureAnalysisTask?.cancel()
+        nativeCaptureAnalysisTask = nil
+        if nativeCaptureSession != nil {
+            _ = stopPreparedNativeCaptureStreaming()
+        }
+        nativeCaptureSession = nil
+    }
+
+    func finishFromNativeCaptureAnalysis(_ error: Error) async {
+        nativeCaptureAnalysisTask = nil
+        await finishFromRecognizerTask(error: error)
+    }
+}
+#endif

--- a/Sources/AuralKit/SpeechSession+NativeFileInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeFileInput.swift
@@ -1,0 +1,48 @@
+import Foundation
+import AVFoundation
+import Speech
+
+#if swift(>=6.4)
+@available(iOS 27.0, macOS 27.0, *)
+extension SpeechSession {
+    nonisolated var shouldUseNativeAssetInputProvider: Bool {
+        get async {
+            await MainActor.run {
+                inputProviderPreference == .automatic
+            }
+        }
+    }
+
+    nonisolated func feedAudioFileWithNativeAnalyzer(
+        _ file: AVAudioFile,
+        progressHandler: (@Sendable (Double) -> Void)?
+    ) async throws -> Bool {
+        guard !Task.isCancelled else { return false }
+
+        if let progressHandler {
+            await MainActor.run {
+                progressHandler(0.0)
+            }
+        }
+
+        guard let analyzer = await MainActor.run(body: { analyzer }) else {
+            throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+
+        let lastAudioTime = try await analyzer.analyzeSequence(from: file)
+        if let lastAudioTime {
+            try await analyzer.finalizeAndFinish(through: lastAudioTime)
+        } else {
+            try await analyzer.finalizeAndFinishThroughEndOfInput()
+        }
+
+        if let progressHandler {
+            await MainActor.run {
+                progressHandler(1.0)
+            }
+        }
+
+        return !Task.isCancelled
+    }
+}
+#endif

--- a/Sources/AuralKit/SpeechSession+NativeFileInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeFileInput.swift
@@ -36,12 +36,6 @@ extension SpeechSession {
             try await analyzer.finalizeAndFinishThroughEndOfInput()
         }
 
-        if let progressHandler {
-            await MainActor.run {
-                progressHandler(1.0)
-            }
-        }
-
         return !Task.isCancelled
     }
 }

--- a/Sources/AuralKit/SpeechSession+NativeFileInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeFileInput.swift
@@ -15,18 +15,17 @@ extension SpeechSession {
 
     nonisolated func feedAudioFileWithNativeAnalyzer(
         _ file: AVAudioFile,
-        progressHandler: (@Sendable (Double) -> Void)?
+        progressHandler _: (@Sendable (Double) -> Void)?
     ) async throws -> Bool {
         guard !Task.isCancelled else { return false }
 
-        if let progressHandler {
-            await MainActor.run {
-                progressHandler(0.0)
-            }
-        }
-
         guard let analyzer = await MainActor.run(body: { analyzer }) else {
             throw SpeechSessionError.recognitionStreamSetupFailed
+        }
+
+        try await prepareAnalyzerForStartIfNeeded(in: file.processingFormat)
+        await MainActor.run {
+            startSpeechDetectorMonitoringIfNeeded()
         }
 
         let lastAudioTime = try await analyzer.analyzeSequence(from: file)

--- a/Sources/AuralKit/SpeechSession+Pipeline.swift
+++ b/Sources/AuralKit/SpeechSession+Pipeline.swift
@@ -81,7 +81,11 @@ extension SpeechSession {
             try await ensurePermissions()
             try await setupAudioSession()
 
-            let transcriber = try await setUpSpeechTranscriber(contextualStrings: contextualStrings)
+            let shouldUseNativeCapture = shouldUseNativeCaptureInputProvider
+            let transcriber = try await setUpSpeechTranscriber(
+                contextualStrings: contextualStrings,
+                startAnalyzerImmediately: !shouldUseNativeCapture
+            )
             if Self.shouldLog(.info) {
                 Self.logger.info("Transcriber prepared with modules")
             }
@@ -91,7 +95,9 @@ extension SpeechSession {
                 streamContinuation: streamContinuation
             )
 
-            try startAudioStreaming()
+            if !(try await setUpNativeCaptureStreamingIfAvailable()) {
+                try startAudioStreaming()
+            }
 
             streamingMode = .liveMicrophone
             setStatus(.transcribing)
@@ -118,7 +124,11 @@ extension SpeechSession {
             try await ensurePermissions()
             try await setupAudioSession()
 
-            let transcriber = try await setUpDictationTranscriber(contextualStrings: contextualStrings)
+            let shouldUseNativeCapture = shouldUseNativeCaptureInputProvider
+            let transcriber = try await setUpDictationTranscriber(
+                contextualStrings: contextualStrings,
+                startAnalyzerImmediately: !shouldUseNativeCapture
+            )
             if Self.shouldLog(.info) {
                 Self.logger.info("Dictation transcriber prepared with modules")
             }
@@ -128,7 +138,9 @@ extension SpeechSession {
                 streamContinuation: streamContinuation
             )
 
-            try startAudioStreaming()
+            if !(try await setUpNativeCaptureStreamingIfAvailable()) {
+                try startAudioStreaming()
+            }
 
             streamingMode = .liveMicrophone
             setStatus(.transcribing)
@@ -191,6 +203,7 @@ extension SpeechSession {
         streamingMode = .inactive
         activeResultKind = nil
         stopAudioStreaming()
+        tearDownNativeCaptureStreaming()
         deactivateAudioSessionIfNeeded()
 #if os(iOS)
         shouldResumeAfterInterruption = false

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -14,7 +14,8 @@ extension SpeechSession {
     // MARK: - Transcriber Setup and Cleanup
 
     func setUpSpeechTranscriber(
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil,
+        startAnalyzerImmediately: Bool = true
     ) async throws -> SpeechTranscriber {
         if Self.shouldLog(.notice) {
             Self.logger.notice("Setting up transcriber")
@@ -24,7 +25,9 @@ extension SpeechSession {
         let modules = configureModules(transcriber: transcriber)
         try await ensureModels(modules: modules)
         try await configureAnalyzerContext(contextualStrings: contextualStrings)
-        try await startAnalyzer(modules: modules)
+        if startAnalyzerImmediately {
+            try await startAnalyzer(modules: modules)
+        }
 
         return transcriber
     }

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -33,7 +33,8 @@ extension SpeechSession {
     }
 
     func setUpDictationTranscriber(
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil,
+        startAnalyzerImmediately: Bool = true
     ) async throws -> DictationTranscriber {
         if Self.shouldLog(.notice) {
             Self.logger.notice("Setting up dictation transcriber")
@@ -43,7 +44,9 @@ extension SpeechSession {
         let modules = configureModules(transcriber: transcriber)
         try await ensureModels(modules: modules)
         try await configureAnalyzerContext(contextualStrings: contextualStrings)
-        try await startAnalyzer(modules: modules)
+        if startAnalyzerImmediately {
+            try await startAnalyzer(modules: modules)
+        }
 
         return transcriber
     }
@@ -119,7 +122,16 @@ extension SpeechSession {
 
         modules.append(transcriber)
 
+#if swift(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, *) {
+            analyzer = SpeechAnalyzer(modules: modules, options: analyzerConfiguration.nativeOptions)
+        } else {
+            analyzer = SpeechAnalyzer(modules: modules)
+        }
+#else
         analyzer = SpeechAnalyzer(modules: modules)
+#endif
+        activeModules = modules
         if Self.shouldLog(.debug) {
             Self.logger.debug("Analyzer instantiated with \(modules.count, privacy: .public) module(s)")
         }
@@ -196,6 +208,8 @@ extension SpeechSession {
             throw SpeechSessionError.recognitionStreamSetupFailed
         }
 
+        try await prepareAnalyzerForStartIfNeeded(in: format)
+
         try await analyzer.start(inputSequence: inputSequence)
         if Self.shouldLog(.info) {
             Self.logger.info("Analyzer started")
@@ -244,6 +258,7 @@ extension SpeechSession {
         inputSequence = nil
         analyzerFormat = nil
         analyzer = nil
+        activeModules = nil
         transcriber = nil
         dictationTranscriber = nil
         if Self.shouldLog(.debug) {

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -215,9 +215,7 @@ extension SpeechSession {
             Self.logger.info("Analyzer started")
         }
 
-        if voiceActivationConfiguration != nil {
-            startSpeechDetectorMonitoring()
-        }
+        startSpeechDetectorMonitoringIfNeeded()
     }
 
     func processAudioBuffer(_ buffer: SendablePCMBuffer) async throws {

--- a/Sources/AuralKit/SpeechSession+Types.swift
+++ b/Sources/AuralKit/SpeechSession+Types.swift
@@ -30,6 +30,15 @@ extension SpeechSession {
         case dictation(AsyncThrowingStream<DictationTranscriber.Result, Error>.Continuation)
     }
 
+    /// Preferred source pipeline for feeding audio into `SpeechAnalyzer`.
+    public enum InputProviderPreference: Equatable, Sendable {
+        /// Use native Speech input sequence providers when the compiler and OS support them.
+        case automatic
+
+        /// Always use AuralKit's AVAudioEngine and buffer conversion pipeline.
+        case legacy
+    }
+
     struct VoiceActivationConfiguration {
         let detectionOptions: SpeechDetector.DetectionOptions
         let reportResults: Bool

--- a/Sources/AuralKit/SpeechSession+VoiceActivation.swift
+++ b/Sources/AuralKit/SpeechSession+VoiceActivation.swift
@@ -71,6 +71,11 @@ extension SpeechSession {
         }
     }
 
+    func startSpeechDetectorMonitoringIfNeeded() {
+        guard voiceActivationConfiguration != nil else { return }
+        startSpeechDetectorMonitoring()
+    }
+
     func handleSpeechDetectorResult(_ result: SpeechDetector.Result) {
         isSpeechDetected = result.speechDetected
         speechDetectorResultsContinuation?.yield(result)

--- a/Sources/AuralKit/SpeechSession.swift
+++ b/Sources/AuralKit/SpeechSession.swift
@@ -46,6 +46,7 @@ public final class SpeechSession {
     let preset: SpeechTranscriber.Preset?
     let reportingOptions: Set<SpeechTranscriber.ReportingOption>
     let attributeOptions: Set<SpeechTranscriber.ResultAttributeOption>
+    let inputProviderPreference: InputProviderPreference
 
     var statusContinuations: [UUID: AsyncStream<Status>.Continuation] = [:]
 
@@ -116,12 +117,14 @@ public final class SpeechSession {
         locale: Locale = .current,
         preset: SpeechTranscriber.Preset? = nil,
         reportingOptions: Set<SpeechTranscriber.ReportingOption> = defaultReportingOptions,
-        attributeOptions: Set<SpeechTranscriber.ResultAttributeOption> = defaultAttributeOptions
+        attributeOptions: Set<SpeechTranscriber.ResultAttributeOption> = defaultAttributeOptions,
+        inputProviderPreference: InputProviderPreference = .automatic
     ) {
         self.locale = locale
         self.preset = preset
         self.reportingOptions = reportingOptions
         self.attributeOptions = attributeOptions
+        self.inputProviderPreference = inputProviderPreference
         self.customVocabularyCompiler = CustomVocabularyCompiler()
 #if os(iOS)
         self.audioConfig = AudioSessionConfiguration.default
@@ -149,12 +152,14 @@ public final class SpeechSession {
         preset: SpeechTranscriber.Preset? = nil,
         reportingOptions: Set<SpeechTranscriber.ReportingOption> = defaultReportingOptions,
         attributeOptions: Set<SpeechTranscriber.ResultAttributeOption> = defaultAttributeOptions,
-        audioConfig: AudioSessionConfiguration = .default
+        audioConfig: AudioSessionConfiguration = .default,
+        inputProviderPreference: InputProviderPreference = .automatic
     ) {
         self.locale = locale
         self.preset = preset
         self.reportingOptions = reportingOptions
         self.attributeOptions = attributeOptions
+        self.inputProviderPreference = inputProviderPreference
         self.audioConfig = audioConfig
         self.customVocabularyCompiler = CustomVocabularyCompiler()
 #if os(iOS) || os(macOS)

--- a/Sources/AuralKit/SpeechSession.swift
+++ b/Sources/AuralKit/SpeechSession.swift
@@ -47,6 +47,7 @@ public final class SpeechSession {
     let reportingOptions: Set<SpeechTranscriber.ReportingOption>
     let attributeOptions: Set<SpeechTranscriber.ResultAttributeOption>
     let inputProviderPreference: InputProviderPreference
+    let analyzerConfiguration: AnalyzerConfiguration
 
     var statusContinuations: [UUID: AsyncStream<Status>.Continuation] = [:]
 
@@ -66,9 +67,12 @@ public final class SpeechSession {
     var dictationTranscriber: DictationTranscriber?
     var speechDetector: SpeechDetector?
     var analyzer: SpeechAnalyzer?
+    var activeModules: [any SpeechModule]?
     var inputSequence: AsyncStream<AnalyzerInput>?
     var inputBuilder: AsyncStream<AnalyzerInput>.Continuation?
     var analyzerFormat: AVAudioFormat?
+    var nativeCaptureSession: AVCaptureSession?
+    var nativeCaptureAnalysisTask: Task<Void, Never>?
     var voiceActivationConfiguration: VoiceActivationConfiguration?
     var customVocabularyDescriptor: CustomVocabulary?
     var customVocabularyConfiguration: SFSpeechLanguageModel.Configuration?
@@ -118,13 +122,15 @@ public final class SpeechSession {
         preset: SpeechTranscriber.Preset? = nil,
         reportingOptions: Set<SpeechTranscriber.ReportingOption> = defaultReportingOptions,
         attributeOptions: Set<SpeechTranscriber.ResultAttributeOption> = defaultAttributeOptions,
-        inputProviderPreference: InputProviderPreference = .automatic
+        inputProviderPreference: InputProviderPreference = .automatic,
+        analyzerConfiguration: AnalyzerConfiguration = .default
     ) {
         self.locale = locale
         self.preset = preset
         self.reportingOptions = reportingOptions
         self.attributeOptions = attributeOptions
         self.inputProviderPreference = inputProviderPreference
+        self.analyzerConfiguration = analyzerConfiguration
         self.customVocabularyCompiler = CustomVocabularyCompiler()
 #if os(iOS)
         self.audioConfig = AudioSessionConfiguration.default
@@ -153,13 +159,15 @@ public final class SpeechSession {
         reportingOptions: Set<SpeechTranscriber.ReportingOption> = defaultReportingOptions,
         attributeOptions: Set<SpeechTranscriber.ResultAttributeOption> = defaultAttributeOptions,
         audioConfig: AudioSessionConfiguration = .default,
-        inputProviderPreference: InputProviderPreference = .automatic
+        inputProviderPreference: InputProviderPreference = .automatic,
+        analyzerConfiguration: AnalyzerConfiguration = .default
     ) {
         self.locale = locale
         self.preset = preset
         self.reportingOptions = reportingOptions
         self.attributeOptions = attributeOptions
         self.inputProviderPreference = inputProviderPreference
+        self.analyzerConfiguration = analyzerConfiguration
         self.audioConfig = audioConfig
         self.customVocabularyCompiler = CustomVocabularyCompiler()
 #if os(iOS) || os(macOS)

--- a/Tests/AuralKitTests/AuralKitTests.swift
+++ b/Tests/AuralKitTests/AuralKitTests.swift
@@ -20,6 +20,19 @@ struct SpeechSessionStateTests {
         #expect(session.inputProviderPreference == .legacy)
     }
 
+    @Test("Analyzer configuration round trips")
+    @MainActor
+    func analyzerConfigurationRoundTrips() {
+        let configuration = SpeechSession.AnalyzerConfiguration(
+            priority: .background,
+            modelRetention: .processLifetime,
+            preparesAnalyzerBeforeStart: false
+        )
+        let session = SpeechSession(analyzerConfiguration: configuration)
+
+        #expect(session.analyzerConfiguration == configuration)
+    }
+
     @Test("Stop transcribing without session is a no-op")
     @MainActor
     func stopTranscribingWithoutSessionIsNoOp() async {

--- a/Tests/AuralKitTests/AuralKitTests.swift
+++ b/Tests/AuralKitTests/AuralKitTests.swift
@@ -12,6 +12,14 @@ struct SpeechSessionStateTests {
         #expect(await session.modelDownloadProgress == nil)
     }
 
+    @Test("Input provider preference can force legacy pipeline")
+    @MainActor
+    func inputProviderPreferenceCanForceLegacyPipeline() {
+        let session = SpeechSession(inputProviderPreference: .legacy)
+
+        #expect(session.inputProviderPreference == .legacy)
+    }
+
     @Test("Stop transcribing without session is a no-op")
     @MainActor
     func stopTranscribingWithoutSessionIsNoOp() async {


### PR DESCRIPTION
## Summary
- Add an input provider preference so callers can force AuralKit's legacy file/audio pipeline.
- Add a Swift 6.4 + iOS/macOS 27 guarded file transcription path using SpeechAnalyzer's native `analyzeSequence(from:)` file input.
- Fix the native file path so completion progress is only emitted once.
- Add a Swift 6.4 + iOS/macOS 27 guarded live microphone path using `CaptureInputSequenceProvider` instead of AuralKit's AVAudioEngine tap when available.
- Add analyzer options/preheating configuration for task priority, model retention, and `prepareToAnalyze(in:)`, with Xcode 26 fallbacks.
- Document the Xcode 27-ready paths and add small API smoke tests.

## Verification
- `swift build`
- `swift test`
- `swiftlint lint --strict`
- `xcodebuild -scheme Aural -project Aural.xcodeproj -destination 'platform=macOS' build`
- `xcodebuild -scheme Aural -project Aural.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`

## Notes
- Current local toolchain is Xcode 26.5 / SDK 26.5, so the Swift 6.4 + OS 27 branches are intentionally hidden behind `#if swift(>=6.4)` and runtime availability checks.
- BufferConverter.swift remains untouched.
