### PR TITLE
[codex] Align README SpeechSession API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,12 +438,13 @@ Use the returned metadata to populate locale pickers, display download guidance,
 ### SpeechSession
 
 ```swift
-public actor SpeechSession {
+@MainActor
+public final class SpeechSession {
     // Initialize with a locale
     public init(locale: Locale = .current)
 
     /// Current speech model download progress, if any
-    public var modelDownloadProgress: Progress? { get async }
+    public var modelDownloadProgress: Progress? { get }
 
     /// Start transcribing - returns stream of SpeechTranscriber.Result
     public func startTranscribing() async -> AsyncThrowingStream<SpeechTranscriber.Result, Error>


### PR DESCRIPTION
## Summary

- Updates the README API reference to describe `SpeechSession` as the actual `@MainActor public final class` implementation.
- Removes the stale `get async` accessor from `modelDownloadProgress` in the documented API snippet.

## Why

The audit found that the README documented an actor/async API that does not exist in the package. This keeps the public docs aligned with the real API surface without changing runtime behavior.

## Validation

- `swift build`
- `swift test`