### PR TITLE
[codex] Fix README transcription API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ AuralKit surfaces detailed `SpeechSessionError` values so you can present action
 
 ```swift
 do {
-    let stream = await kit.startTranscribing()
+    let stream = session.startTranscribing()
     for try await segment in stream {
         // Use the transcription
     }
@@ -447,7 +447,7 @@ public final class SpeechSession {
     public var modelDownloadProgress: Progress? { get }
 
     /// Start transcribing - returns stream of SpeechTranscriber.Result
-    public func startTranscribing() async -> AsyncThrowingStream<SpeechTranscriber.Result, Error>
+    public func startTranscribing() -> AsyncThrowingStream<SpeechTranscriber.Result, Error>
 
     /// Stop transcribing
     public func stopTranscribing() async


### PR DESCRIPTION
## Summary

Fixes two stale README references that survived the earlier SpeechSession API docs cleanup:

- removes `await` from the documented `startTranscribing()` signature
- updates the error-handling sample to call the defined `session` value instead of an undefined `kit`

## Impact

The README now matches the current non-async `SpeechSession.startTranscribing()` API and the sample can be copied without an undefined symbol.

## Validation

- `swift test`
- `rg -n "await kit\.startTranscribing|startTranscribing\(\) async" README.md || true`

Note: full `swiftlint lint --strict` still reports pre-existing violations in untouched Swift files.