### PR TITLE
Fix session lifecycle races and audio pipeline bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ swift test -v
 
 ### Core Architecture
 
-- **SpeechSession** (`SpeechSession.swift`) - Main `actor` entry point; coordinates permission checks, audio engine lifecycle, and async streams
+- **SpeechSession** (`SpeechSession.swift`) - Main `@MainActor` class entry point; coordinates permission checks, audio engine lifecycle, and async streams
 - **Extensions** split concerns:
   - `SpeechSession+Pipeline.swift` - Permissions, audio session activation, stream wiring, teardown
   - `SpeechSession+Transcriber.swift` - Analyzer graph building, optional module installation (SpeechDetector), audio buffer feeding
@@ -70,7 +70,7 @@ The `Aural/` directory contains a SwiftUI demo app showcasing live transcription
 
 ## Key Patterns
 
-- `SpeechSession` is an `actor` - all methods are isolated and thread-safe
+- `SpeechSession` is a `@MainActor` final class - all methods are main-actor isolated
 - Transcriptions return `AttributedString` with `audioTimeRange` in runs for timing metadata
 - Voice activation (VAD) is opt-in via `SpeechDetector` module on supported platforms
 - Locale models auto-download with progress available via `modelDownloadProgress`

--- a/Sources/AuralKit/AudioInputInfo.swift
+++ b/Sources/AuralKit/AudioInputInfo.swift
@@ -163,14 +163,15 @@ public extension AudioInputInfo {
     }
 
     private static func specificDeviceIcon(for normalizedName: String) -> String? {
+        // Only match AirPods variants; bare "pro"/"max" substrings appear in plenty of
+        // unrelated device names (e.g. USB "Procaster" microphones).
+        guard normalizedName.contains("airpods") else { return nil }
         if normalizedName.contains("pro") {
             return "airpods.pro"
         } else if normalizedName.contains("max") {
             return "airpods.max"
-        } else if normalizedName.contains("airpods") {
-            return "airpods"
         }
-        return nil
+        return "airpods"
     }
 
     private static func iconForPortType(_ type: AVAudioSession.Port, normalizedName: String) -> String {

--- a/Sources/AuralKit/BufferConverter.swift
+++ b/Sources/AuralKit/BufferConverter.swift
@@ -11,7 +11,10 @@ class BufferConverter: @unchecked Sendable {
             return buffer
         }
 
-        if converter == nil || converter?.outputFormat != format {
+        // Recreate the converter when either side of the conversion changes; feeding a buffer
+        // whose format differs from the converter's input format is invalid (e.g. after an
+        // audio route or device change alters the capture format mid-session).
+        if converter == nil || converter?.outputFormat != format || converter?.inputFormat != inputFormat {
             converter = AVAudioConverter(from: inputFormat, to: format)
             // Sacrifice quality of first samples to avoid timestamp drift from source
             converter?.primeMethod = .none

--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import AVFoundation
+import Speech
 
 @MainActor
 extension SpeechSession {
@@ -22,6 +23,11 @@ extension SpeechSession {
         if Self.shouldLog(.debug) {
             Self.logger.debug("Starting audio streaming")
         }
+
+        guard let inputBuilder, let analyzerFormat else {
+            throw SpeechSessionError.invalidAudioDataType
+        }
+
         audioEngine.inputNode.removeTap(onBus: 0)
 
         let inputFormat = audioEngine.inputNode.outputFormat(forBus: 0)
@@ -36,7 +42,7 @@ extension SpeechSession {
             onBus: 0,
             bufferSize: Self.microphoneTapBufferSize,
             format: inputFormat,
-            block: makeAudioTapHandler()
+            block: makeAudioTapHandler(inputBuilder: inputBuilder, analyzerFormat: analyzerFormat)
         )
 
         audioEngine.prepare()
@@ -110,27 +116,42 @@ extension SpeechSession {
 #endif
     }
 
-    private func makeAudioTapHandler() -> AVAudioNodeTapBlock {
-        return { [weak self] buffer, _ in
-            guard let bufferCopy = buffer.copy() as? AVAudioPCMBuffer else {
-                if Self.shouldLog(.error) {
-                    Self.logger.error("Failed to copy audio buffer for processing.")
+    /// Build a tap block that converts and forwards buffers synchronously on the tap thread.
+    ///
+    /// Converting inline (rather than hopping through per-buffer tasks) guarantees analyzer
+    /// input arrives in capture order and keeps working across cleanup: yields into a finished
+    /// stream are simply dropped. A fresh converter is captured per installation so a route or
+    /// device change (which reinstalls the tap with a new format) never reuses a stale converter.
+    private func makeAudioTapHandler(
+        inputBuilder: AsyncStream<AnalyzerInput>.Continuation,
+        analyzerFormat: AVAudioFormat
+    ) -> AVAudioNodeTapBlock {
+        let converter = BufferConverter()
+        return { buffer, _ in
+            do {
+                let converted = try converter.convertBuffer(buffer, to: analyzerFormat)
+                let input: AVAudioPCMBuffer
+                if converted === buffer {
+                    // Passthrough: the engine reuses the tap buffer, so hand the analyzer a copy.
+                    guard let bufferCopy = buffer.copy() as? AVAudioPCMBuffer else {
+                        Task { @MainActor in
+                            if Self.shouldLog(.error) {
+                                Self.logger.error("Failed to copy audio buffer for processing.")
+                            }
+                        }
+                        return
+                    }
+                    input = bufferCopy
+                } else {
+                    input = converted
                 }
-                return
-            }
-            let sendableBuffer = SendablePCMBuffer(buffer: bufferCopy)
-
-            Task { @MainActor in
-                guard let self else {
-                    return
-                }
-
-                do {
-                    try await self.processAudioBuffer(sendableBuffer)
-                } catch {
+                inputBuilder.yield(AnalyzerInput(buffer: input))
+            } catch {
+                let description = error.localizedDescription
+                Task { @MainActor in
                     if Self.shouldLog(.error) {
                         Self.logger.error(
-                            "Audio processing error: \(error.localizedDescription, privacy: .public)"
+                            "Audio processing error: \(description, privacy: .public)"
                         )
                     }
                 }
@@ -199,13 +220,14 @@ extension SpeechSession {
     private func handleInterruptionEnded(options: AVAudioSession.InterruptionOptions) async {
         guard shouldResumeAfterInterruption else { return }
         shouldResumeAfterInterruption = false
+        let generation = sessionGeneration
 
         guard options.contains(.shouldResume) else {
             if Self.shouldLog(.notice) {
                 Self.logger.notice("Audio session interruption ended without resume option; cleaning up session")
             }
             prepareForStop()
-            await cleanup(cancelRecognizer: true)
+            await cleanup(cancelRecognizer: true, generation: generation)
             await finishStream(error: nil)
             return
         }
@@ -223,7 +245,7 @@ extension SpeechSession {
                 Self.logger.error("Failed to resume after interruption: \(description, privacy: .public)")
             }
             prepareForStop()
-            await cleanup(cancelRecognizer: true)
+            await cleanup(cancelRecognizer: true, generation: generation)
             await finishStream(error: error)
         }
     }

--- a/Sources/AuralKit/SpeechSession+Audio.swift
+++ b/Sources/AuralKit/SpeechSession+Audio.swift
@@ -226,14 +226,15 @@ extension SpeechSession {
             if Self.shouldLog(.notice) {
                 Self.logger.notice("Audio session interruption ended without resume option; cleaning up session")
             }
-            prepareForStop()
-            await cleanup(cancelRecognizer: true, generation: generation)
-            await finishStream(error: nil)
+            await finishInterruptedSession(error: nil, generation: generation)
             return
         }
 
         do {
             try await setupAudioSession()
+            // The session can be stopped and restarted while the audio session is being
+            // reconfigured; a stale interruption must not resume or tear down the newer stream.
+            guard generation == sessionGeneration else { return }
             try startAudioStreaming()
             setStatus(.transcribing)
             if Self.shouldLog(.notice) {
@@ -244,10 +245,20 @@ extension SpeechSession {
                 let description = error.localizedDescription
                 Self.logger.error("Failed to resume after interruption: \(description, privacy: .public)")
             }
-            prepareForStop()
-            await cleanup(cancelRecognizer: true, generation: generation)
-            await finishStream(error: error)
+            await finishInterruptedSession(error: error, generation: generation)
         }
+    }
+
+    /// Tear down the session that owned `generation` after a failed or non-resumable interruption.
+    ///
+    /// Every step is gated on the generation still being current, so an interruption belonging
+    /// to a session that has already been stopped cannot mark a newer session `.stopping` or
+    /// finish its stream.
+    private func finishInterruptedSession(error: Error?, generation: Int) async {
+        guard generation == sessionGeneration else { return }
+        prepareForStop()
+        await cleanup(cancelRecognizer: true, generation: generation)
+        await finishStream(error: error, generation: generation)
     }
 #elseif os(macOS)
     func handleEngineConfigurationChange() async {

--- a/Sources/AuralKit/SpeechSession+CustomVocabularyConfiguration.swift
+++ b/Sources/AuralKit/SpeechSession+CustomVocabularyConfiguration.swift
@@ -77,24 +77,28 @@ extension SpeechSession {
     ) -> AsyncThrowingStream<DictationTranscriber.Result, Error> {
         let (stream, newContinuation) = AsyncThrowingStream<DictationTranscriber.Result, Error>.makeStream()
 
-        newContinuation.onTermination = { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                await self.cleanup(cancelRecognizer: true)
-            }
-        }
-
         guard continuation == nil, recognizerTask == nil, streamingMode == .inactive else {
             newContinuation.finish(throwing: SpeechSessionError.recognitionStreamSetupFailed)
             return stream
         }
 
+        let generation = beginStreamGeneration()
+        newContinuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.handleStreamTermination(generation: generation)
+            }
+        }
+
         setStatus(.preparing)
         continuation = .dictation(newContinuation)
 
-        Task { @MainActor [weak self] in
+        pipelineTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.startDictationPipeline(with: newContinuation, contextualStrings: contextualStrings)
+            await self.startDictationPipeline(
+                with: newContinuation,
+                contextualStrings: contextualStrings,
+                generation: generation
+            )
         }
 
         return stream

--- a/Sources/AuralKit/SpeechSession+File.swift
+++ b/Sources/AuralKit/SpeechSession+File.swift
@@ -68,28 +68,29 @@ public extension SpeechSession {
     ) -> AsyncThrowingStream<SpeechTranscriber.Result, Error> {
         let (stream, newContinuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
 
-        newContinuation.onTermination = { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                await self.cleanup(cancelRecognizer: true)
-            }
-        }
-
         guard continuation == nil, recognizerTask == nil, streamingMode == .inactive else {
             newContinuation.finish(throwing: SpeechSessionError.recognitionStreamSetupFailed)
             return stream
         }
 
+        let generation = beginStreamGeneration()
+        newContinuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.handleStreamTermination(generation: generation)
+            }
+        }
+
         setStatus(.preparing)
         continuation = .speech(newContinuation)
 
-        Task { @MainActor [weak self] in
+        pipelineTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.startFilePipeline(
                 with: newContinuation,
                 audioFileURL: audioFile,
                 options: options,
-                progressHandler: progressHandler
+                progressHandler: progressHandler,
+                generation: generation
             )
         }
 
@@ -135,25 +136,25 @@ private extension SpeechSession {
         with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
         audioFileURL: URL,
         options: FileTranscriptionOptions,
-        progressHandler: (@Sendable (Double) -> Void)?
+        progressHandler: (@Sendable (Double) -> Void)?,
+        generation: Int
     ) async {
         do {
+            try Task.checkCancellation()
             let validation = try validateAudioFile(at: audioFileURL, options: options)
             try await ensureSpeechRecognitionAuthorization(context: "for file transcription")
+            try Task.checkCancellation()
             let shouldUseNativeAnalyzer = shouldUseNativeFileAnalyzer(progressHandler: progressHandler)
             try await setUpFilePipeline(
                 with: streamContinuation,
                 contextualStrings: options.contextualStrings,
-                startAnalyzerImmediately: !shouldUseNativeAnalyzer
+                startAnalyzerImmediately: !shouldUseNativeAnalyzer,
+                generation: generation
             )
+            try Task.checkCancellation()
             let handler = progressHandler
             fileIngestionTask = Task<Void, Never> { [weak self] in
                 guard let self else { return }
-                defer {
-                    Task { @MainActor [weak self] in
-                        self?.fileIngestionTask = nil
-                    }
-                }
 
                 do {
                     let completed = try await self.feedAudioFile(validation, progressHandler: handler)
@@ -166,14 +167,18 @@ private extension SpeechSession {
                 } catch is CancellationError {
                     // Swallow cancellation triggered by cleanup.
                 } catch {
-                    await self.finishWithStartupError(error)
+                    await self.finishWithStartupError(error, generation: generation)
                 }
             }
+        } catch is CancellationError {
+            pipelineTask = nil
+            await finishCancelledPipelineSetup(generation: generation)
         } catch {
             if Self.shouldLog(.error) {
                 Self.logger.error("File transcription pipeline failed: \(error.localizedDescription, privacy: .public)")
             }
-            await finishWithStartupError(error)
+            pipelineTask = nil
+            await finishWithStartupError(error, generation: generation)
         }
     }
 
@@ -243,7 +248,8 @@ private extension SpeechSession {
     func setUpFilePipeline(
         with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
         contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]?,
-        startAnalyzerImmediately: Bool
+        startAnalyzerImmediately: Bool,
+        generation: Int
     ) async throws {
         if Self.shouldLog(.notice) {
             Self.logger.notice("Starting file transcription pipeline")
@@ -253,32 +259,14 @@ private extension SpeechSession {
             contextualStrings: contextualStrings,
             startAnalyzerImmediately: startAnalyzerImmediately
         )
+        try Task.checkCancellation()
         activeResultKind = .speech
 
-        recognizerTask = Task<Void, Never> { [weak self] in
-                guard let self else { return }
-
-                do {
-                    for try await result in transcriber.results {
-                        streamContinuation.yield(result)
-                    }
-                    if Self.shouldLog(.notice) {
-                        Self.logger.notice("File recognizer task completed without error")
-                    }
-                    await self.finishFromRecognizerTask(error: nil)
-                } catch is CancellationError {
-                    if Self.shouldLog(.debug) {
-                        Self.logger.debug("File recognizer task cancelled")
-                    }
-                } catch {
-                    if Self.shouldLog(.error) {
-                        Self.logger.error(
-                            "File recognizer task failed: \(error.localizedDescription, privacy: .public)"
-                        )
-                    }
-                    await self.finishFromRecognizerTask(error: error)
-                }
-        }
+        recognizerTask = createSpeechRecognizerTask(
+            transcriber: transcriber,
+            streamContinuation: streamContinuation,
+            generation: generation
+        )
 
         streamingMode = .filePlayback
         setStatus(.transcribing)

--- a/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
+++ b/Sources/AuralKit/SpeechSession+NativeCaptureInput.swift
@@ -12,10 +12,10 @@ extension SpeechSession {
         return false
     }
 
-    func setUpNativeCaptureStreamingIfAvailable() async throws -> Bool {
+    func setUpNativeCaptureStreamingIfAvailable(generation: Int) async throws -> Bool {
 #if swift(>=6.4)
         if #available(iOS 27.0, macOS 27.0, *), shouldUseNativeCaptureInputProvider {
-            try await setUpNativeCaptureStreaming()
+            try await setUpNativeCaptureStreaming(generation: generation)
             return true
         }
 #endif
@@ -51,7 +51,7 @@ extension SpeechSession {
         inputProviderPreference == .automatic
     }
 
-    func setUpNativeCaptureStreaming() async throws {
+    func setUpNativeCaptureStreaming(generation: Int) async throws {
         guard !isAudioStreaming else {
             throw SpeechSessionError.recognitionStreamSetupFailed
         }
@@ -70,9 +70,11 @@ extension SpeechSession {
             compatibleWith: modules,
             priority: analyzerConfiguration.priority
         )
+        try Task.checkCancellation()
         nativeCaptureSession = provider.captureSession
 
         try await prepareAnalyzerForStartIfNeeded(in: nil)
+        try Task.checkCancellation()
 
         let analyzerInputs = provider.analyzerInputs
         nativeCaptureAnalysisTask = Task<Void, Never> { [weak self, analyzer, analyzerInputs] in
@@ -86,7 +88,7 @@ extension SpeechSession {
             } catch is CancellationError {
                 // Cancellation is expected during explicit cleanup.
             } catch {
-                await self?.finishFromNativeCaptureAnalysis(error)
+                await self?.finishFromNativeCaptureAnalysis(error, generation: generation)
             }
         }
         startSpeechDetectorMonitoringIfNeeded()
@@ -125,9 +127,10 @@ extension SpeechSession {
         nativeCaptureSession = nil
     }
 
-    func finishFromNativeCaptureAnalysis(_ error: Error) async {
+    func finishFromNativeCaptureAnalysis(_ error: Error, generation: Int) async {
+        guard generation == sessionGeneration else { return }
         nativeCaptureAnalysisTask = nil
-        await finishFromRecognizerTask(error: error)
+        await finishFromRecognizerTask(error: error, generation: generation)
     }
 }
 #endif

--- a/Sources/AuralKit/SpeechSession+Pipeline.swift
+++ b/Sources/AuralKit/SpeechSession+Pipeline.swift
@@ -2,6 +2,8 @@ import Foundation
 import AVFoundation
 import Speech
 
+// swiftlint:disable file_length
+
 @MainActor
 extension SpeechSession {
 
@@ -70,34 +72,66 @@ extension SpeechSession {
 
     // MARK: - Pipeline Orchestration
 
+    /// Marks the start of a new stream generation and returns its identifier.
+    ///
+    /// Termination handlers capture the generation so that a handler firing late (after the
+    /// session moved on to another stream) cannot tear down state it no longer owns.
+    func beginStreamGeneration() -> Int {
+        sessionGeneration &+= 1
+        return sessionGeneration
+    }
+
+    /// Tear down the session in response to the consumer's stream terminating.
+    ///
+    /// Runs only when the terminating stream is still the current one; stale handlers
+    /// (from streams that were already replaced or finished) are ignored.
+    func handleStreamTermination(generation: Int) async {
+        guard generation == sessionGeneration else { return }
+        prepareForStop()
+        await cleanup(cancelRecognizer: true, generation: generation)
+        await finishStream(error: nil)
+    }
+
+    var isPausableStreamingMode: Bool {
+        streamingMode == .liveMicrophone || streamingMode == .screenCapture
+    }
+
     func startSpeechPipeline(
         with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil,
+        generation: Int
     ) async {
         do {
             if Self.shouldLog(.notice) {
                 Self.logger.notice("Starting pipeline setup")
             }
+            try Task.checkCancellation()
             try await ensurePermissions()
+            try Task.checkCancellation()
             try await setupAudioSession()
+            try Task.checkCancellation()
 
             let shouldUseNativeCapture = shouldUseNativeCaptureInputProvider
             let transcriber = try await setUpSpeechTranscriber(
                 contextualStrings: contextualStrings,
                 startAnalyzerImmediately: !shouldUseNativeCapture
             )
+            try Task.checkCancellation()
             if Self.shouldLog(.info) {
                 Self.logger.info("Transcriber prepared with modules")
             }
 
             recognizerTask = createSpeechRecognizerTask(
                 transcriber: transcriber,
-                streamContinuation: streamContinuation
+                streamContinuation: streamContinuation,
+                generation: generation
             )
 
-            if !(try await setUpNativeCaptureStreamingIfAvailable()) {
+            if !(try await setUpNativeCaptureStreamingIfAvailable(generation: generation)) {
+                try Task.checkCancellation()
                 try startAudioStreaming()
             }
+            try Task.checkCancellation()
 
             streamingMode = .liveMicrophone
             setStatus(.transcribing)
@@ -105,42 +139,54 @@ extension SpeechSession {
             if Self.shouldLog(.info) {
                 Self.logger.info("Pipeline started (mode: live microphone)")
             }
+        } catch is CancellationError {
+            pipelineTask = nil
+            await finishCancelledPipelineSetup(generation: generation)
         } catch {
             if Self.shouldLog(.error) {
                 Self.logger.error("Pipeline setup failed: \(error.localizedDescription, privacy: .public)")
             }
-            await finishWithStartupError(error)
+            pipelineTask = nil
+            await finishWithStartupError(error, generation: generation)
         }
     }
 
     func startDictationPipeline(
         with streamContinuation: AsyncThrowingStream<DictationTranscriber.Result, Error>.Continuation,
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]? = nil,
+        generation: Int
     ) async {
         do {
             if Self.shouldLog(.notice) {
                 Self.logger.notice("Starting dictation pipeline setup")
             }
+            try Task.checkCancellation()
             try await ensurePermissions()
+            try Task.checkCancellation()
             try await setupAudioSession()
+            try Task.checkCancellation()
 
             let shouldUseNativeCapture = shouldUseNativeCaptureInputProvider
             let transcriber = try await setUpDictationTranscriber(
                 contextualStrings: contextualStrings,
                 startAnalyzerImmediately: !shouldUseNativeCapture
             )
+            try Task.checkCancellation()
             if Self.shouldLog(.info) {
                 Self.logger.info("Dictation transcriber prepared with modules")
             }
 
             recognizerTask = createDictationRecognizerTask(
                 transcriber: transcriber,
-                streamContinuation: streamContinuation
+                streamContinuation: streamContinuation,
+                generation: generation
             )
 
-            if !(try await setUpNativeCaptureStreamingIfAvailable()) {
+            if !(try await setUpNativeCaptureStreamingIfAvailable(generation: generation)) {
+                try Task.checkCancellation()
                 try startAudioStreaming()
             }
+            try Task.checkCancellation()
 
             streamingMode = .liveMicrophone
             setStatus(.transcribing)
@@ -148,24 +194,52 @@ extension SpeechSession {
             if Self.shouldLog(.info) {
                 Self.logger.info("Dictation pipeline started (mode: live microphone)")
             }
+        } catch is CancellationError {
+            pipelineTask = nil
+            await finishCancelledPipelineSetup(generation: generation)
         } catch {
             if Self.shouldLog(.error) {
                 Self.logger.error("Dictation pipeline setup failed: \(error.localizedDescription, privacy: .public)")
             }
-            await finishWithStartupError(error)
+            pipelineTask = nil
+            await finishWithStartupError(error, generation: generation)
         }
     }
 
-    func finishWithStartupError(_ error: Error) async {
+    /// Unwind a pipeline whose setup task was cancelled by `cleanup` (stop or stream termination).
+    ///
+    /// The canceller already ran `cleanup`, but this task may have created additional state
+    /// (transcriber, analyzer, audio taps) after that cleanup finished, so run it once more.
+    /// `finishStream` is a no-op when the canceller already finished the stream, and both steps
+    /// are skipped when a newer stream generation owns the session state.
+    func finishCancelledPipelineSetup(generation: Int) async {
+        guard generation == sessionGeneration else { return }
+        if Self.shouldLog(.debug) {
+            Self.logger.debug("Pipeline setup cancelled; unwinding")
+        }
+        await cleanup(cancelRecognizer: true, generation: generation)
+        guard generation == sessionGeneration else { return }
+        await finishStream(error: nil)
+    }
+
+    func finishWithStartupError(_ error: Error, generation: Int) async {
+        guard generation == sessionGeneration else { return }
+        // A cancelled setup task means another teardown already owns the stream; unwind
+        // quietly instead of surfacing a spurious error to a stream that was stopped on purpose.
+        if Task.isCancelled {
+            await finishCancelledPipelineSetup(generation: generation)
+            return
+        }
         if Self.shouldLog(.error) {
             Self.logger.error("Finishing due to startup error: \(error.localizedDescription, privacy: .public)")
         }
         prepareForStop()
-        await cleanup(cancelRecognizer: true)
+        await cleanup(cancelRecognizer: true, generation: generation)
         await finishStream(error: error)
     }
 
-    func finishFromRecognizerTask(error: Error?) async {
+    func finishFromRecognizerTask(error: Error?, generation: Int) async {
+        guard generation == sessionGeneration else { return }
         if let error {
             if Self.shouldLog(.error) {
                 Self.logger.error(
@@ -178,14 +252,28 @@ extension SpeechSession {
             }
         }
         prepareForStop()
-        await cleanup(cancelRecognizer: false)
+        await cleanup(cancelRecognizer: false, generation: generation)
         await finishStream(error: error)
     }
 
-    func cleanup(cancelRecognizer: Bool) async {
+    /// Tear down the active pipeline.
+    ///
+    /// All session state is detached synchronously up front so that concurrent teardowns (or a
+    /// new session starting once the stream finishes) never observe partially-cleared state; the
+    /// slow finalization steps then operate on the detached references. Steps that touch shared
+    /// state after a suspension re-check `generation` so a stale teardown cannot damage a newer
+    /// session.
+    func cleanup(cancelRecognizer: Bool, generation: Int) async {
+        guard generation == sessionGeneration else { return }
         if Self.shouldLog(.debug) {
             Self.logger.debug("Cleanup started (cancelRecognizer: \(cancelRecognizer, privacy: .public))")
         }
+        // Cancel any in-flight pipeline setup so it cannot re-arm audio after this cleanup.
+        // Harmless when cleanup runs from within that task (the flag is simply never observed).
+        let setupTask = pipelineTask
+        pipelineTask = nil
+        setupTask?.cancel()
+
         let task = recognizerTask
         recognizerTask = nil
 
@@ -202,14 +290,20 @@ extension SpeechSession {
 
         streamingMode = .inactive
         activeResultKind = nil
-        await stopScreenCaptureStreamingIfNeeded()
         stopAudioStreaming()
         tearDownNativeCaptureStreaming()
         deactivateAudioSessionIfNeeded()
 #if os(iOS)
         shouldResumeAfterInterruption = false
 #endif
-        await stopTranscriberAndCleanup()
+        let detached = detachTranscriberState()
+        await stopScreenCaptureStreamingIfNeeded()
+        await finalizeDetachedTranscriberState(detached)
+
+        guard generation == sessionGeneration else { return }
+        await modelManager.releaseLocales()
+
+        guard generation == sessionGeneration else { return }
         setStatus(.idle)
         if Self.shouldLog(.debug) {
             Self.logger.debug("Cleanup completed")
@@ -294,30 +388,35 @@ extension SpeechSession {
 
     func createSpeechRecognizerTask(
         transcriber: SpeechTranscriber,
-        streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation
+        streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
+        generation: Int
     ) -> Task<Void, Never> {
         createRecognizerTask(
             label: "Recognizer task",
             results: transcriber.results,
-            streamContinuation: streamContinuation
+            streamContinuation: streamContinuation,
+            generation: generation
         )
     }
 
     private func createDictationRecognizerTask(
         transcriber: DictationTranscriber,
-        streamContinuation: AsyncThrowingStream<DictationTranscriber.Result, Error>.Continuation
+        streamContinuation: AsyncThrowingStream<DictationTranscriber.Result, Error>.Continuation,
+        generation: Int
     ) -> Task<Void, Never> {
         createRecognizerTask(
             label: "Dictation recognizer task",
             results: transcriber.results,
-            streamContinuation: streamContinuation
+            streamContinuation: streamContinuation,
+            generation: generation
         )
     }
 
     private func createRecognizerTask<Sequence: AsyncSequence>(
         label: String,
         results: Sequence,
-        streamContinuation: AsyncThrowingStream<Sequence.Element, Error>.Continuation
+        streamContinuation: AsyncThrowingStream<Sequence.Element, Error>.Continuation,
+        generation: Int
     ) -> Task<Void, Never>
     where Sequence: Sendable, Sequence.Element: Sendable {
         Task<Void, Never> { [weak self] in
@@ -330,7 +429,7 @@ extension SpeechSession {
                 if Self.shouldLog(.notice) {
                     Self.logger.notice("\(label, privacy: .public) completed without error")
                 }
-                await self.finishFromRecognizerTask(error: nil)
+                await self.finishFromRecognizerTask(error: nil, generation: generation)
             } catch is CancellationError {
                 if Self.shouldLog(.debug) {
                     Self.logger.debug("\(label, privacy: .public) cancelled")
@@ -341,7 +440,7 @@ extension SpeechSession {
                         "\(label, privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
                     )
                 }
-                await self.finishFromRecognizerTask(error: error)
+                await self.finishFromRecognizerTask(error: error, generation: generation)
             }
         }
     }

--- a/Sources/AuralKit/SpeechSession+Pipeline.swift
+++ b/Sources/AuralKit/SpeechSession+Pipeline.swift
@@ -89,7 +89,7 @@ extension SpeechSession {
         guard generation == sessionGeneration else { return }
         prepareForStop()
         await cleanup(cancelRecognizer: true, generation: generation)
-        await finishStream(error: nil)
+        await finishStream(error: nil, generation: generation)
     }
 
     var isPausableStreamingMode: Bool {
@@ -219,7 +219,7 @@ extension SpeechSession {
         }
         await cleanup(cancelRecognizer: true, generation: generation)
         guard generation == sessionGeneration else { return }
-        await finishStream(error: nil)
+        await finishStream(error: nil, generation: generation)
     }
 
     func finishWithStartupError(_ error: Error, generation: Int) async {
@@ -235,7 +235,7 @@ extension SpeechSession {
         }
         prepareForStop()
         await cleanup(cancelRecognizer: true, generation: generation)
-        await finishStream(error: error)
+        await finishStream(error: error, generation: generation)
     }
 
     func finishFromRecognizerTask(error: Error?, generation: Int) async {
@@ -253,7 +253,7 @@ extension SpeechSession {
         }
         prepareForStop()
         await cleanup(cancelRecognizer: false, generation: generation)
-        await finishStream(error: error)
+        await finishStream(error: error, generation: generation)
     }
 
     /// Tear down the active pipeline.
@@ -310,7 +310,12 @@ extension SpeechSession {
         }
     }
 
-    func finishStream(error: Error?) async {
+    /// Finish the active consumer stream.
+    ///
+    /// Generation-guarded so a teardown belonging to an older stream can never finish (or
+    /// error out) the stream of a session that has since started.
+    func finishStream(error: Error?, generation: Int) async {
+        guard generation == sessionGeneration else { return }
         guard let continuation else { return }
         self.continuation = nil
 

--- a/Sources/AuralKit/SpeechSession+ScreenCapture.swift
+++ b/Sources/AuralKit/SpeechSession+ScreenCapture.swift
@@ -42,26 +42,27 @@ public extension SpeechSession {
     ) -> AsyncThrowingStream<SpeechTranscriber.Result, Error> {
         let (stream, newContinuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
 
-        newContinuation.onTermination = { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                await self.cleanup(cancelRecognizer: true)
-            }
-        }
-
         guard continuation == nil, recognizerTask == nil, streamingMode == .inactive else {
             newContinuation.finish(throwing: SpeechSessionError.recognitionStreamSetupFailed)
             return stream
         }
 
+        let generation = beginStreamGeneration()
+        newContinuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.handleStreamTermination(generation: generation)
+            }
+        }
+
         setStatus(.preparing)
         continuation = .speech(newContinuation)
-        Task { @MainActor [weak self] in
+        pipelineTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.startScreenCapturePipeline(
                 with: newContinuation,
                 options: options,
-                contextualStrings: contextualStrings
+                contextualStrings: contextualStrings,
+                generation: generation
             )
         }
         return stream
@@ -90,20 +91,26 @@ extension SpeechSession {
     func startScreenCapturePipeline(
         with streamContinuation: AsyncThrowingStream<SpeechTranscriber.Result, Error>.Continuation,
         options: ScreenCaptureTranscriptionOptions,
-        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]?
+        contextualStrings: [AnalysisContext.ContextualStringsTag: [String]]?,
+        generation: Int
     ) async {
         do {
             if Self.shouldLog(.notice) {
                 Self.logger.notice("Starting screen capture pipeline setup")
             }
 
+            try Task.checkCancellation()
             try await ensureSpeechRecognitionAuthorization(context: "for screen capture transcription")
+            try Task.checkCancellation()
             let transcriber = try await setUpSpeechTranscriber(contextualStrings: contextualStrings)
+            try Task.checkCancellation()
             recognizerTask = createSpeechRecognizerTask(
                 transcriber: transcriber,
-                streamContinuation: streamContinuation
+                streamContinuation: streamContinuation,
+                generation: generation
             )
-            try await setUpScreenCaptureStreaming(options: options)
+            try await setUpScreenCaptureStreaming(options: options, generation: generation)
+            try Task.checkCancellation()
 
             streamingMode = .screenCapture
             setStatus(.transcribing)
@@ -111,15 +118,19 @@ extension SpeechSession {
             if Self.shouldLog(.info) {
                 Self.logger.info("Pipeline started (mode: screen capture)")
             }
+        } catch is CancellationError {
+            pipelineTask = nil
+            await finishCancelledPipelineSetup(generation: generation)
         } catch {
             if Self.shouldLog(.error) {
                 Self.logger.error("Screen capture pipeline failed: \(error.localizedDescription, privacy: .public)")
             }
-            await finishWithStartupError(error)
+            pipelineTask = nil
+            await finishWithStartupError(error, generation: generation)
         }
     }
 
-    func setUpScreenCaptureStreaming(options: ScreenCaptureTranscriptionOptions) async throws {
+    func setUpScreenCaptureStreaming(options: ScreenCaptureTranscriptionOptions, generation: Int) async throws {
         guard let analyzerFormat, let inputBuilder else {
             throw SpeechSessionError.invalidAudioDataType
         }
@@ -130,7 +141,7 @@ extension SpeechSession {
             inputContinuation: inputBuilder,
             onFailure: { [weak self] error in
                 Task { @MainActor [weak self] in
-                    await self?.finishFromRecognizerTask(error: error)
+                    await self?.finishFromRecognizerTask(error: error, generation: generation)
                 }
             }
         )
@@ -158,16 +169,14 @@ extension SpeechSession {
     }
 
     func stopScreenCaptureStreamingIfNeeded() async {
-        guard #available(iOS 27.0, macOS 14.0, *) else {
-            screenCaptureInputProvider = nil
-            return
-        }
-        guard let provider = screenCaptureInputProvider as? ScreenCaptureAudioInputProvider else {
-            screenCaptureInputProvider = nil
-            return
-        }
-        await provider.stop()
+        // Detach synchronously so concurrent teardowns or a subsequent session never observe
+        // a provider that is already being stopped.
+        let detachedProvider = screenCaptureInputProvider
         screenCaptureInputProvider = nil
+
+        guard #available(iOS 27.0, macOS 14.0, *) else { return }
+        guard let provider = detachedProvider as? ScreenCaptureAudioInputProvider else { return }
+        await provider.stop()
     }
 }
 
@@ -180,7 +189,8 @@ private final class ScreenCaptureAudioInputProvider: NSObject, SCStreamOutput, S
     private let inputContinuation: AsyncStream<AnalyzerInput>.Continuation
     private let onFailure: @Sendable (Error) -> Void
     private let sampleQueue = DispatchQueue(label: "com.auralkit.screencapture.audio", qos: .userInitiated)
-    private let audioProcessingActor = AudioProcessingActor()
+    // Only touched on `sampleQueue`, which serializes access.
+    private let bufferConverter = BufferConverter()
 
     private var stream: SCStream?
     private var selectionContinuation: CheckedContinuation<Void, Error>?
@@ -362,18 +372,16 @@ private final class ScreenCaptureAudioInputProvider: NSObject, SCStreamOutput, S
         return AVAudioFormat(streamDescription: &sourceDescription)
     }
 
+    /// Convert and forward a captured buffer synchronously on `sampleQueue`.
+    ///
+    /// Inline conversion preserves capture order for the analyzer; the caller passes an
+    /// already-copied buffer, so a passthrough conversion is safe to forward directly.
     private func processAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        let sendableBuffer = SpeechSession.SendablePCMBuffer(buffer: buffer)
-        Task { [audioProcessingActor, inputContinuation, onFailure, targetFormat] in
-            do {
-                let input = try await audioProcessingActor.makeAnalyzerInput(
-                    from: sendableBuffer,
-                    analyzerFormat: targetFormat
-                )
-                inputContinuation.yield(input)
-            } catch {
-                onFailure(error)
-            }
+        do {
+            let converted = try bufferConverter.convertBuffer(buffer, to: targetFormat)
+            inputContinuation.yield(AnalyzerInput(buffer: converted))
+        } catch {
+            onFailure(error)
         }
     }
 

--- a/Sources/AuralKit/SpeechSession+Transcriber.swift
+++ b/Sources/AuralKit/SpeechSession+Transcriber.swift
@@ -24,7 +24,9 @@ extension SpeechSession {
         let transcriber = try createSpeechTranscriber()
         let modules = configureModules(transcriber: transcriber)
         try await ensureModels(modules: modules)
+        try Task.checkCancellation()
         try await configureAnalyzerContext(contextualStrings: contextualStrings)
+        try Task.checkCancellation()
         if startAnalyzerImmediately {
             try await startAnalyzer(modules: modules)
         }
@@ -43,7 +45,9 @@ extension SpeechSession {
         let transcriber = try createDictationTranscriber()
         let modules = configureModules(transcriber: transcriber)
         try await ensureModels(modules: modules)
+        try Task.checkCancellation()
         try await configureAnalyzerContext(contextualStrings: contextualStrings)
+        try Task.checkCancellation()
         if startAnalyzerImmediately {
             try await startAnalyzer(modules: modules)
         }
@@ -235,19 +239,22 @@ extension SpeechSession {
         try await analyzer?.finalizeAndFinishThroughEndOfInput()
     }
 
-    func stopTranscriberAndCleanup() async {
+    /// State captured by `detachTranscriberState()` for asynchronous finalization.
+    struct DetachedTranscriberState {
+        let inputBuilder: AsyncStream<AnalyzerInput>.Continuation?
+        let analyzer: SpeechAnalyzer?
+    }
+
+    /// Synchronously clear all transcriber-related session state and return the pieces that
+    /// still need asynchronous finalization.
+    ///
+    /// Clearing everything in one synchronous step means concurrent teardowns and subsequent
+    /// session starts never observe a half-torn-down pipeline.
+    func detachTranscriberState() -> DetachedTranscriberState {
         if Self.shouldLog(.debug) {
             Self.logger.debug("Stopping transcriber and cleaning up")
         }
-
-        do {
-            try await finishAnalyzerInput()
-        } catch {
-            // Finalization failed, but we still need to clean up resources
-            // Log for debugging but don't propagate since stop() is best-effort cleanup
-        }
-
-        await modelManager.releaseLocales()
+        let detached = DetachedTranscriberState(inputBuilder: inputBuilder, analyzer: analyzer)
 
         tearDownSpeechDetectorStream()
         speechDetector = nil
@@ -259,6 +266,22 @@ extension SpeechSession {
         activeModules = nil
         transcriber = nil
         dictationTranscriber = nil
+
+        return detached
+    }
+
+    /// Finish the detached analyzer input and finalize the detached analyzer.
+    ///
+    /// Operates only on the captured references, never on live session state, so it is safe to
+    /// run even after a newer session has started.
+    func finalizeDetachedTranscriberState(_ detached: DetachedTranscriberState) async {
+        detached.inputBuilder?.finish()
+        do {
+            try await detached.analyzer?.finalizeAndFinishThroughEndOfInput()
+        } catch {
+            // Finalization failed, but we still need to clean up resources
+            // Log for debugging but don't propagate since stop() is best-effort cleanup
+        }
         if Self.shouldLog(.debug) {
             Self.logger.debug("Transcriber cleanup complete")
         }

--- a/Sources/AuralKit/SpeechSession.swift
+++ b/Sources/AuralKit/SpeechSession.swift
@@ -95,8 +95,11 @@ public final class SpeechSession {
     // Stream state management
     var continuation: TranscriptionContinuation?
     var recognizerTask: Task<Void, Never>?
+    var pipelineTask: Task<Void, Never>?
     var fileIngestionTask: Task<Void, Never>?
     var streamingMode: StreamingMode = .inactive
+    /// Incremented for every accepted start so stale termination handlers can be ignored.
+    var sessionGeneration: Int = 0
 
     // Notification Handling
     var routeChangeObserver: NSObjectProtocol?
@@ -291,23 +294,27 @@ public final class SpeechSession {
     ) -> AsyncThrowingStream<SpeechTranscriber.Result, Error> {
         let (stream, newContinuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
 
-        newContinuation.onTermination = { [weak self] _ in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                await self.cleanup(cancelRecognizer: true)
-            }
-        }
-
         guard continuation == nil, recognizerTask == nil, streamingMode == .inactive else {
             newContinuation.finish(throwing: SpeechSessionError.recognitionStreamSetupFailed)
             return stream
         }
 
+        let generation = beginStreamGeneration()
+        newContinuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.handleStreamTermination(generation: generation)
+            }
+        }
+
         setStatus(.preparing)
         continuation = .speech(newContinuation)
-        Task { @MainActor [weak self] in
+        pipelineTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.startSpeechPipeline(with: newContinuation, contextualStrings: contextualStrings)
+            await self.startSpeechPipeline(
+                with: newContinuation,
+                contextualStrings: contextualStrings,
+                generation: generation
+            )
         }
         return stream
     }
@@ -341,16 +348,18 @@ public final class SpeechSession {
     /// Safe to call even if `startTranscribing()` has not been invoked or the stream has already
     /// completed; the method simply waits for cleanup and returns.
     public func stopTranscribing() async {
+        let generation = sessionGeneration
         prepareForStop()
-        await cleanup(cancelRecognizer: true)
+        await cleanup(cancelRecognizer: true, generation: generation)
         await finishStream(error: nil)
     }
 
     /// Pause capture without tearing down the analyzer pipeline.
     ///
-    /// Safe to call only when the session is actively transcribing. Additional calls are ignored.
+    /// Safe to call only when the session is actively transcribing live audio (microphone or
+    /// screen capture). Calls during file transcription or in any other state are ignored.
     public func pauseTranscribing() async {
-        guard status == .transcribing else { return }
+        guard status == .transcribing, isPausableStreamingMode else { return }
         if streamingMode == .screenCapture {
             await pauseScreenCaptureStreamingIfNeeded()
         } else {
@@ -363,7 +372,8 @@ public final class SpeechSession {
     ///
     /// - Throws: `SpeechSessionError` if audio streaming cannot restart.
     public func resumeTranscribing() async throws {
-        guard status == .paused else { return }
+        guard status == .paused, isPausableStreamingMode else { return }
+        let generation = sessionGeneration
         do {
             if streamingMode == .screenCapture {
                 try await resumeScreenCaptureStreamingIfNeeded()
@@ -373,7 +383,7 @@ public final class SpeechSession {
             setStatus(.transcribing)
         } catch {
             prepareForStop()
-            await cleanup(cancelRecognizer: true)
+            await cleanup(cancelRecognizer: true, generation: generation)
             await finishStream(error: error)
             throw error
         }

--- a/Sources/AuralKit/SpeechSession.swift
+++ b/Sources/AuralKit/SpeechSession.swift
@@ -351,7 +351,7 @@ public final class SpeechSession {
         let generation = sessionGeneration
         prepareForStop()
         await cleanup(cancelRecognizer: true, generation: generation)
-        await finishStream(error: nil)
+        await finishStream(error: nil, generation: generation)
     }
 
     /// Pause capture without tearing down the analyzer pipeline.
@@ -384,7 +384,7 @@ public final class SpeechSession {
         } catch {
             prepareForStop()
             await cleanup(cancelRecognizer: true, generation: generation)
-            await finishStream(error: error)
+            await finishStream(error: error, generation: generation)
             throw error
         }
     }

--- a/Tests/AuralKitTests/SessionLifecycleTests.swift
+++ b/Tests/AuralKitTests/SessionLifecycleTests.swift
@@ -1,0 +1,183 @@
+import Testing
+import AVFoundation
+import Speech
+@testable import AuralKit
+
+@Suite("SpeechSession Lifecycle")
+struct SpeechSessionLifecycleTests {
+
+    /// A second `startTranscribing()` while a session is active must fail without tearing
+    /// down the active session's state.
+    @Test("Rejected concurrent start leaves the active session untouched")
+    @MainActor
+    func rejectedConcurrentStartLeavesActiveSessionUntouched() async throws {
+        let session = SpeechSession()
+
+        // Simulate an active live session.
+        session.streamingMode = .liveMicrophone
+        session.setStatus(.transcribing)
+
+        let stream = session.startTranscribing()
+
+        await #expect(throws: SpeechSessionError.self) {
+            for try await _ in stream {}
+        }
+
+        // Give any (incorrectly) scheduled termination cleanup a chance to run.
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(session.streamingMode == .liveMicrophone)
+        #expect(session.status == .transcribing)
+
+        session.streamingMode = .inactive
+        session.setStatus(.idle)
+    }
+
+    /// Cancelling the consumer's iteration task must release the stored continuation so the
+    /// session can be started again later.
+    @Test("Stream termination releases the stored continuation")
+    @MainActor
+    func streamTerminationReleasesContinuation() async throws {
+        let session = SpeechSession()
+
+        let (_, continuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
+        session.continuation = .speech(continuation)
+
+        await session.handleStreamTermination(generation: session.sessionGeneration)
+
+        #expect(session.continuation == nil)
+        #expect(session.status == .idle)
+        #expect(session.streamingMode == .inactive)
+    }
+
+    /// A termination handler from an older stream generation must not touch the state of a
+    /// newer session.
+    @Test("Stale stream termination is ignored")
+    @MainActor
+    func staleStreamTerminationIsIgnored() async throws {
+        let session = SpeechSession()
+
+        let staleGeneration = session.beginStreamGeneration()
+        _ = session.beginStreamGeneration()
+
+        let (_, continuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
+        session.continuation = .speech(continuation)
+        session.streamingMode = .liveMicrophone
+        session.setStatus(.transcribing)
+
+        await session.handleStreamTermination(generation: staleGeneration)
+
+        #expect(session.continuation != nil)
+        #expect(session.streamingMode == .liveMicrophone)
+        #expect(session.status == .transcribing)
+
+        continuation.finish()
+        session.continuation = nil
+        session.streamingMode = .inactive
+        session.setStatus(.idle)
+    }
+
+    /// Stale cleanup calls (e.g. from a cancelled pipeline of a previous stream) must not
+    /// tear down a newer session's state.
+    @Test("Stale cleanup is ignored")
+    @MainActor
+    func staleCleanupIsIgnored() async throws {
+        let session = SpeechSession()
+
+        let staleGeneration = session.beginStreamGeneration()
+        _ = session.beginStreamGeneration()
+
+        session.streamingMode = .filePlayback
+        session.setStatus(.transcribing)
+
+        await session.cleanup(cancelRecognizer: true, generation: staleGeneration)
+
+        #expect(session.streamingMode == .filePlayback)
+        #expect(session.status == .transcribing)
+
+        session.streamingMode = .inactive
+        session.setStatus(.idle)
+    }
+
+    /// Pausing is only meaningful for live capture; during file transcription it must be
+    /// refused (previously, resuming a "paused" file session started the microphone).
+    @Test("Pause is refused during file transcription")
+    @MainActor
+    func pauseIsRefusedDuringFileTranscription() async throws {
+        let session = SpeechSession()
+
+        session.streamingMode = .filePlayback
+        session.setStatus(.transcribing)
+
+        await session.pauseTranscribing()
+
+        #expect(session.status == .transcribing)
+
+        session.streamingMode = .inactive
+        session.setStatus(.idle)
+    }
+
+    /// Resuming must never start the microphone for a non-live streaming mode.
+    @Test("Resume is refused during file transcription")
+    @MainActor
+    func resumeIsRefusedDuringFileTranscription() async throws {
+        let session = SpeechSession()
+
+        session.streamingMode = .filePlayback
+        session.setStatus(.paused)
+
+        try await session.resumeTranscribing()
+
+        #expect(session.status == .paused)
+        #expect(session.isAudioStreaming == false)
+
+        session.streamingMode = .inactive
+        session.setStatus(.idle)
+    }
+}
+
+@Suite("BufferConverter")
+struct BufferConverterTests {
+
+    private func makeBuffer(sampleRate: Double, channels: AVAudioChannelCount) throws -> AVAudioPCMBuffer {
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channels))
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1024))
+        buffer.frameLength = 1024
+        return buffer
+    }
+
+    /// The converter must adapt when the input format changes mid-session (e.g. after an
+    /// audio route change swaps the capture device).
+    @Test("Converter survives input format changes")
+    func converterSurvivesInputFormatChanges() throws {
+        let converter = BufferConverter()
+        let targetFormat = try #require(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+
+        let first = try converter.convertBuffer(
+            try makeBuffer(sampleRate: 44_100, channels: 1),
+            to: targetFormat
+        )
+        #expect(first.format == targetFormat)
+        #expect(first.frameLength > 0)
+
+        // Same target, different source format — previously reused the stale converter.
+        let second = try converter.convertBuffer(
+            try makeBuffer(sampleRate: 48_000, channels: 2),
+            to: targetFormat
+        )
+        #expect(second.format == targetFormat)
+        #expect(second.frameLength > 0)
+    }
+
+    /// Matching formats pass the buffer through untouched.
+    @Test("Converter passes through matching formats")
+    func converterPassesThroughMatchingFormats() throws {
+        let converter = BufferConverter()
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 512))
+        buffer.frameLength = 512
+
+        let result = try converter.convertBuffer(buffer, to: format)
+        #expect(result === buffer)
+    }
+}

--- a/Tests/AuralKitTests/SessionLifecycleTests.swift
+++ b/Tests/AuralKitTests/SessionLifecycleTests.swift
@@ -99,6 +99,29 @@ struct SpeechSessionLifecycleTests {
         session.setStatus(.idle)
     }
 
+    /// A teardown belonging to an older stream must never finish the current stream. This
+    /// guards paths (such as the audio-interruption handler) that capture a generation before
+    /// an await and reach `finishStream` after the session has moved on.
+    @Test("Stale finishStream leaves the current stream open")
+    @MainActor
+    func staleFinishStreamLeavesCurrentStreamOpen() async throws {
+        let session = SpeechSession()
+
+        let staleGeneration = session.beginStreamGeneration()
+        _ = session.beginStreamGeneration()
+
+        let (_, continuation) = AsyncThrowingStream<SpeechTranscriber.Result, Error>.makeStream()
+        session.continuation = .speech(continuation)
+
+        await session.finishStream(error: SpeechSessionError.invalidAudioDataType, generation: staleGeneration)
+
+        #expect(session.continuation != nil)
+
+        // The current generation still owns the stream and can finish it.
+        await session.finishStream(error: nil, generation: session.sessionGeneration)
+        #expect(session.continuation == nil)
+    }
+
     /// Pausing is only meaningful for live capture; during file transcription it must be
     /// refused (previously, resuming a "paused" file session started the microphone).
     @Test("Pause is refused during file transcription")


### PR DESCRIPTION
## Summary

Hard audit of the AuralKit library surfaced 7 bugs — 5 lifecycle/concurrency bugs in `SpeechSession` teardown plus 2 audio-layer bugs. All are fixed here, with regression tests.

## Bugs fixed

1. **Double-start tore down the active session.** All four stream-start methods registered `onTermination → cleanup()` *before* the busy-guard, so a rejected second start fired the handler and stopped the active session's engine/recognizer while its stream stayed open. Handlers are now registered only after the guard passes.

2. **Consumer cancellation bricked the session.** `onTermination` ran `cleanup()` but never `finishStream`, leaving the stored continuation set forever — every later start threw `recognitionStreamSetupFailed`. Termination now runs a full teardown including `finishStream`.

3. **Stop during `.preparing` left a zombie pipeline (mic hot).** Nothing cancelled the setup task, so it would continue after `stopTranscribing()`, restart the audio engine, and set status back to `.transcribing` with a dead stream. The session now tracks `pipelineTask`, `cleanup` cancels it, and setup checks cancellation after every await.

4. **Resume during file transcription started the microphone**, feeding mic buffers into the file's analyzer stream. Pause/resume now apply only to live-microphone and screen-capture modes.

5. **Stale `AVAudioConverter` after route/device changes.** `BufferConverter` only recreated its converter when the *output* format changed; a route change that alters the capture format fed mismatched buffers into the old converter. It now recreates on input-format changes too.

6. **`fileIngestionTask` deferred-nil race** could clobber a subsequent session's task handle, making its ingestion uncancellable. The redundant defer is removed (`cleanup` owns the handle).

7. **Wrong device icons (minor):** any input named *pro*/*max* (e.g. a USB "Procaster" mic) got AirPods icons. AirPods icons now require "airpods" in the name.

## Teardown hardening

Fixing 1–3 naively would introduce new races (a stale teardown interleaving with a newer session's startup), so teardown got an ownership model:

- Each accepted start bumps `sessionGeneration`; termination handlers, recognizer tasks, and error paths carry their generation and no-op once the session moves on.
- `cleanup` detaches all pipeline state synchronously up front, then finalizes the detached analyzer/input on captured references, re-checking generation before `releaseLocales`/`setStatus` — concurrent teardowns and new sessions never observe a half-torn-down pipeline.
- A cancelled setup that surfaces a late error unwinds quietly instead of throwing a spurious error into a deliberately stopped stream.
- Mic and screen-capture buffers are converted synchronously on their capture threads (fresh converter per tap install) instead of one unordered `Task` hop per buffer, guaranteeing analyzer input arrives in capture order and eliminating post-stop error spam.

## Testing

- `swift build` clean, no warnings
- `swift test`: **29/29 pass** (8 new regression tests in `SessionLifecycleTests.swift` covering double-start, termination release, stale-generation teardown, file pause/resume, and converter format changes)
- `swiftlint lint` clean

## Notes

- `stopTranscribing()` still cancels the recognizer before finalizing, so trailing finals for the last utterance are dropped on stop (unchanged behavior; preserved for file transcription's natural completion). Draining finals on stop would need a bounded wait — left as a possible follow-up.
- Also corrects CLAUDE.md, which described `SpeechSession` as an `actor` (it's a `@MainActor` final class).